### PR TITLE
Fixed Azure.VNET.UseNSGs #261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed incorrect string formatting in POSIX culture.  [#262](https://github.com/Microsoft/PSRule.Rules.Azure/issues/262)
+- Fixed `Azure.VNET.UseNSGs` to exclude `AzureFirewallSubnet`. [#261](https://github.com/Microsoft/PSRule.Rules.Azure/issues/261)
 
 ## v0.8.0
 

--- a/docs/rules/en/Azure.AppGw.SSLPolicy.md
+++ b/docs/rules/en/Azure.AppGw.SSLPolicy.md
@@ -17,4 +17,9 @@ Application Gateway should only accept a minimum of TLS 1.2.
 
 ## RECOMMENDATION
 
-Application Gateway should only accept a minimum of TLS 1.2.
+Consider configuring Application Gateway to accept a minimum of TLS 1.2.
+
+## LINKS
+
+- [Application Gateway SSL policy overview](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview)
+- [Configure SSL policy versions and cipher suites on Application Gateway](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-configure-ssl-policy-powershell)

--- a/docs/rules/en/Azure.VNET.UseNSGs.md
+++ b/docs/rules/en/Azure.VNET.UseNSGs.md
@@ -13,9 +13,15 @@ Subnets should have NSGs assigned.
 
 ## DESCRIPTION
 
-Virtual network subnets should have network security groups (NSGs) assigned.
+Virtual network subnets should have a network security group (NSG) assigned.
+NSGs are a basic stateful firewall that can be assigned to a virtual machine network interface or a subnets.
 
 ## RECOMMENDATION
 
-The GatewaySubnet is a special named subnet which does not support NSGs.
-For all other subnets define and assign a NSG.
+The GatewaySubnet and AzureFirewallSubnet are special named subnets which does not support NSGs.
+For all other subnets, define and assign a NSG.
+
+## LINKS
+
+- [Network Security Best Practices](https://docs.microsoft.com/en-us/azure/security/fundamentals/network-best-practices#logically-segment-subnets)
+- [Azure Firewall FAQ](https://docs.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups-nsgs-supported-on-the-azure-firewall-subnet)

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -12,12 +12,12 @@ Rule 'Azure.VNET.UseNSGs' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.
     $subnet = @($TargetObject);
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         # Get subnets
-        $subnet = @($TargetObject.properties.subnets | Where-Object { $_.Name -ne 'GatewaySubnet' });
+        $subnet = @($TargetObject.properties.subnets | Where-Object { $_.Name -notin 'GatewaySubnet', 'AzureFirewallSubnet' });
         if ($subnet.Length -eq 0) {
             return $True;
         }
     }
-    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets' -and $PSRule.TargetName -eq 'GatewaySubnet') {
+    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets' -and $PSRule.TargetName -in 'GatewaySubnet', 'AzureFirewallSubnet') {
         return $True;
     }
     foreach ($sn in $subnet) {


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.VNET.UseNSGs` to exclude `AzureFirewallSubnet`. #261

Fixes #261 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
