### PR TITLE
Pre-release v0.9.0-B2002011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0-B2002011 (pre-release)
+
 - Fixed incorrect string formatting in POSIX culture.  [#262](https://github.com/Microsoft/PSRule.Rules.Azure/issues/262)
 - Fixed `Azure.VNET.UseNSGs` to exclude `AzureFirewallSubnet`. [#261](https://github.com/Microsoft/PSRule.Rules.Azure/issues/261)
 


### PR DESCRIPTION
## PR Summary

- Fixed incorrect string formatting in POSIX culture.  #262
- Fixed `Azure.VNET.UseNSGs` to exclude `AzureFirewallSubnet`. #261

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
