### PR TITLE
Remove Az.Security in install instructions

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -33,10 +33,10 @@ stages:
       matrix:
         Linux:
           displayName: 'Linux'
-          imageName: 'ubuntu-latest'
+          imageName: 'ubuntu-18.04'
         MacOS:
           displayName: 'MacOS'
-          imageName: 'macOS-latest'
+          imageName: 'macOS-10.15'
         Windows:
           displayName: 'Windows'
           imageName: 'vs2017-win2016'

--- a/docs/scenarios/install-instructions.md
+++ b/docs/scenarios/install-instructions.md
@@ -12,7 +12,6 @@ The following modules are required for `PSRule.Rules.Azure` to work:
 - PSRule
 - Az.Accounts
 - Az.Resources
-- Az.Security
 
 The required version of each module will automatically be installed along-side `PSRule.Rules.Azure` when using `Install-Module` or `Update-Module` cmdlets.
 
@@ -38,7 +37,7 @@ Save for offline use from PowerShell Gallery:
 
 ```powershell
 # Save module, in the .\modules directory
-Save-Module -Name 'PSRule', 'PSRule.Rules.Azure', 'Az.Accounts', 'Az.Resources', 'Az.Security' -Path '.\modules';
+Save-Module -Name 'PSRule', 'PSRule.Rules.Azure', 'Az.Accounts', 'Az.Resources' -Path '.\modules';
 ```
 
 > For pre-release versions the `-AllowPrerelease` switch must be added when calling `Install-Module` or `Save-Module`.

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>PSRule.Rules.Azure</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## PR Summary

- Remove reference to `Az.Security` which is no longer a dependency in module install instructions.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
