### PR TITLE
Removed warning for azureAllowedRegions #328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added support for linking parameter and template files for analysis with metadata. [#324](https://github.com/Microsoft/PSRule.Rules.Azure/issues/324)
+- Removed warning message for `azureAllowedRegions` option. [#328](https://github.com/Microsoft/PSRule.Rules.Azure/issues/328)
 
 ## v0.10.0-B2003032 (pre-release)
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -5,10 +5,6 @@
 # Validation rules for Azure resources
 #
 
-if ($Null -eq $Configuration.azureAllowedRegions) {
-    Write-Warning -Message 'The azureAllowedRegions option is not configured';
-}
-
 # Synopsis: Resources should be tagged
 Rule 'Azure.Resource.UseTags' -If { (SupportsTags) } -Tag @{ release = 'GA' } {
     Reason $LocalizedData.ResourceNotTagged


### PR DESCRIPTION
## PR Summary

- Removed warning message for `azureAllowedRegions` option. #328

Fixes #328 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
