### PR TITLE
Fix false positives for resources #336 #337 #338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed false positive for unused public IP in templates. [#336](https://github.com/Microsoft/PSRule.Rules.Azure/issues/336)
+  - Fixed false positive for use of managed disks in templates. [#337](https://github.com/Microsoft/PSRule.Rules.Azure/issues/337)
+  - Fixed false positive for disk caching when no VM data disks is null in templates. [#338](https://github.com/Microsoft/PSRule.Rules.Azure/issues/338)
+
 ## v0.10.0
 
 What's changed since v0.9.0:

--- a/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PublicIP.Rule.ps1
@@ -6,6 +6,6 @@
 #
 
 # Synopsis: Public IP addresses should be attached or cleaned up if not in use
-Rule 'Azure.PublicIP.IsAttached' -Type 'Microsoft.Network/publicIPAddresses' -Tag @{ release = 'GA' } {
+Rule 'Azure.PublicIP.IsAttached' -Type 'Microsoft.Network/publicIPAddresses' -If { IsExport } -Tag @{ release = 'GA' } {
     $Assert.HasFieldValue($TargetObject, 'Properties.ipConfiguration.id')
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualMachine.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualMachine.Tests.ps1
@@ -461,13 +461,13 @@ Describe 'Azure.VirtualMachine' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vm-A';
+            $ruleResult | Should -BeNullOrEmpty;
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vm-A';
         }
 
         It 'Azure.VM.Standalone' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template3.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template3.json
@@ -19,7 +19,9 @@
             "defaultValue": "fddiag01"
         }
     },
-    "variables": {},
+    "variables": {
+        "publicIPName": "pip-001"
+    },
     "resources": [
         {
             "apiVersion": "2019-04-01",
@@ -177,6 +179,15 @@
             },
             "kind": "Storage",
             "properties": {}
+        },
+        {
+            "apiVersion": "2016-03-30",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
         }
     ],
     "outputs": {},

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualMachine.json
@@ -396,7 +396,10 @@
                         "name": "vm-B_disk2_0000000000000000000000000000000",
                         "createOption": "Empty",
                         "caching": "ReadOnly",
-                        "diskSizeGB": 1023
+                        "diskSizeGB": 1023,
+                        "vhd": {
+                            "uri": "[concat('http://testsa.blob.core.windows.net/vhds/vm-B_disk2_0000000000000000000000000000000.vhd')]"
+                        }
                     }
                 ]
             },
@@ -509,8 +512,7 @@
                         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg/providers/Microsoft.Compute/disks/aks-agentpool-00000000-1_OsDisk_1_0000000000000000000000000000000"
                     },
                     "diskSizeGB": 30
-                },
-                "dataDisks": []
+                }
             },
             "osProfile": {
                 "computerName": "aks-agentpool-00000000-1",


### PR DESCRIPTION
## PR Summary

- Bug fixes:
  - Fixed false positive for unused public IP in templates. #336
  - Fixed false positive for use of managed disks in templates. #337
  - Fixed false positive for disk caching when no VM data disks is null in templates. #338

Fixes #336 
Fixes #337 
Fixes #338 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
