### PR TITLE
Renamed configuration options to use a standard prefix #327

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - New rules:
   - Azure Kubernetes Service:
     - Check AKS nodes use a minimum number of pods. [#274](https://github.com/Microsoft/PSRule.Rules.Azure/issues/274)
+- General improvements:
+  - **Breaking change**: Renamed configuration options to use a standard prefix. [#327](https://github.com/Microsoft/PSRule.Rules.Azure/issues/327)
+    - Configuration options use the `Azure_` prefix.
+    - Update configuration settings to use the new name, old configuration names are ignored.
+    - Renamed `minAKSVersion` to `Azure_AKSMinimumVersion`.
+    - Renamed `azureAllowedRegions` to `Azure_AllowedRegions`.
+    - Added configuration option documentation. See [about_PSRule_Azure_Configuration](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md) for details.
 
 ## v0.11.0-B2004005 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ The following commands exist in the `PSRule.Rules.Azure` module:
 The following conceptual topics exist in the `PSRule.Rules.Azure` module:
 
 - [Azure metadata link](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Metadata_Link.md)
+- [Configuration](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md)
+  - [Azure_AKSMinimumVersion](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_aksminimumversion)
+  - [Azure_AKSNodeMinimumMaxPods](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_aksnodeminimummaxpods)
+  - [Azure_AllowedRegions](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_allowedregions)
+  - [Azure_MinimumCertificateLifetime](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_minimumcertificatelifetime)
 
 ## Changes and versioning
 

--- a/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
@@ -1,0 +1,151 @@
+# PSRule_Azure_Configuration
+
+## about_PSRule_Azure_Configuration
+
+## SHORT DESCRIPTION
+
+Describes PSRule configuration options specific to `PSRule.Rules.Azure`.
+
+## LONG DESCRIPTION
+
+PSRule exposes configuration options that can be used to customize execution of `PSRule.Rules.Azure`.
+This topic describes what configuration options are available.
+
+PSRule configuration options can be specified by setting the configuration option in `ps-rule.yaml`.
+Additionally, configuration options can be configured in a baseline or set at runtime.
+For details of setting configuration options see [PSRule options][options]
+
+The following configurations options are available for use:
+
+- [Azure_AKSMinimumVersion](#azure_aksminimumversion)
+- [Azure_AKSNodeMinimumMaxPods](#azure_aksnodeminimummaxpods)
+- [Azure_AllowedRegions](#azure_allowedregions)
+- [Azure_MinimumCertificateLifetime](#azure_minimumcertificatelifetime)
+
+### Azure_AKSMinimumVersion
+
+This configuration option determines the minimum version of Kubernetes for AKS clusters and node pools.
+Rules that check the Kubernetes version fail when the version is older than the version specified.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_AKSMinimumVersion: string # A version string
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_AKSMinimumVersion configuration option
+configuration:
+  Azure_AKSMinimumVersion: 1.16.7
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_AKSMinimumVersion configuration option to 1.17.0
+configuration:
+  Azure_AKSMinimumVersion: 1.17.0
+```
+
+### Azure_AKSNodeMinimumMaxPods
+
+This configuration option determines the minimum allowed max pods setting per node pool.
+When an AKS cluster node pool is created, a `maxPods` option is used to determine the maximum number of pods for each node in the node pool.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_AKSNodeMinimumMaxPods: integer
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_AKSNodeMinimumMaxPods configuration option
+configuration:
+  Azure_AKSNodeMinimumMaxPods: 50
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_AKSNodeMinimumMaxPods configuration option to 30
+configuration:
+  Azure_AKSNodeMinimumMaxPods: 30
+```
+
+### Azure_AllowedRegions
+
+This configuration option specifies a list of allowed locations that resources can be deployed to.
+Rules that check the location of Azure resources fail when a resource or resource group is created in a different region.
+
+By default, `Azure_AllowedRegions` is not configured.
+The rule `Azure.Resource.AllowedRegions` is skipped when no allowed locations are configured.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_AllowedRegions: array # An array of regions
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_AllowedRegions configuration option
+configuration:
+  Azure_AllowedRegions: []
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_AllowedRegions configuration option to Australia East, Australia South East
+configuration:
+  Azure_AllowedRegions:
+  - 'australiaeast'
+  - 'australiasoutheast'
+```
+
+### Azure_MinimumCertificateLifetime
+
+This configuration option determines the minimum number of days allowed before certificate expiry.
+Rules that check certificate lifetime fail when the days remaining before expiry drop below this number.
+
+Syntax:
+
+```yaml
+configuration:
+  Azure_MinimumCertificateLifetime: integer
+```
+
+Default:
+
+```yaml
+# YAML: The default Azure_MinimumCertificateLifetime configuration option
+configuration:
+  Azure_MinimumCertificateLifetime: 30
+```
+
+Example:
+
+```yaml
+# YAML: Set the Azure_MinimumCertificateLifetime configuration option to 90
+configuration:
+  Azure_MinimumCertificateLifetime: 90
+```
+
+## NOTE
+
+An online version of this document is available at https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md.
+
+## KEYWORDS
+
+- Configuration
+- Rule
+
+[options]: https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html

--- a/docs/rules/en/Azure.AKS.NodeMinPods.md
+++ b/docs/rules/en/Azure.AKS.NodeMinPods.md
@@ -27,11 +27,11 @@ Consider deploying node pools with a minimum number of pods per node.
 
 ## NOTES
 
-By default, this rule fails when node pools have a maxPods set to less than 50.
+By default, this rule fails when node pools have `maxPods` set to less than 50.
 
 To configure this rule:
 
-- Override the Azure_AKSNodeMinimumPods configuration value with the minimum number of pods.
+- Override the `Azure_AKSNodeMinimumMaxPods` configuration value with the minimum maxPods.
 
 ## LINKS
 

--- a/docs/rules/en/Azure.AKS.Version.md
+++ b/docs/rules/en/Azure.AKS.Version.md
@@ -23,6 +23,12 @@ A list of available Kubernetes versions can be found using the `az aks get-versi
 
 Consider upgrading AKS control plan and nodes pools to the latest stable version of Kubernetes.
 
+## NOTES
+
+To configure this rule:
+
+- Override the `Azure_AKSMinimumVersion` configuration value with the minimum Kubernetes version.
+
 ## LINKS
 
 - [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions).

--- a/docs/rules/en/Azure.APIM.CertificateExpiry.md
+++ b/docs/rules/en/Azure.APIM.CertificateExpiry.md
@@ -29,7 +29,7 @@ By default, this rule fails when certificates have less than 30 days remaining b
 
 To configure this rule:
 
-- Override the Azure_MinimumCertificateLifetime configuration value with the minimum number of days until expiry that should pass.
+- Override the `Azure_MinimumCertificateLifetime` configuration value with the minimum number of days until expiry.
 
 ## LINKS
 

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 @{
+    ConfigurationOptionReplaced = "The configuration option '{0}' has been replaced with '{1}'."
     MinTLSVersion = "Minimum TLS version is set to {0}."
     ResourceNotTagged = "The resource is not tagged."
-    AllowedRegionsNotConfigured = "The azureAllowedRegions option is not configured."
     TcpHealthProbe = "The health probe ({0}) is using TCP."
     RootHttpProbePath = "The health probe ({0}) is using '{1}'."
     AKSVersion = "The Kubernetes version is v{0}."

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -5,6 +5,10 @@
 # Validation rules for Azure Kubernetes Service (AKS)
 #
 
+if ($Null -ne $Configuration.minAKSVersion) {
+    Write-Warning -Message ($LocalizedData.ConfigurationOptionReplaced -f 'minAKSVersion', 'Azure_AKSMinimumVersion');
+}
+
 # Synopsis: AKS clusters should have minimum number of nodes for failover and updates
 Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
     $TargetObject.Properties.agentPoolProfiles[0].count -ge 3
@@ -12,7 +16,7 @@ Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters'
 
 # Synopsis: AKS clusters should meet the minimum version
 Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA' } {
-    $minVersion = [Version]$Configuration.minAKSVersion
+    $minVersion = [Version]$Configuration.Azure_AKSMinimumVersion
     if ($PSRule.TargetType -eq 'Microsoft.ContainerService/managedClusters') {
         ([Version]$TargetObject.Properties.kubernetesVersion) -ge $minVersion
         Reason ($LocalizedData.AKSVersion -f $TargetObject.Properties.kubernetesVersion);
@@ -22,7 +26,7 @@ Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Mi
             (([Version]$TargetObject.Properties.orchestratorVersion) -ge $minVersion)
         Reason ($LocalizedData.AKSVersion -f $TargetObject.Properties.orchestratorVersion);
     }
-} -Configure @{ minAKSVersion = '1.16.7' }
+} -Configure @{ Azure_AKSMinimumVersion = '1.16.7' }
 
 # Synopsis: AKS agent pools should run the same Kubernetes version as the cluster
 Rule 'Azure.AKS.PoolVersion' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
@@ -82,6 +86,6 @@ Rule 'Azure.AKS.NodeMinPods' -Type 'Microsoft.ContainerService/managedClusters',
         $agentPools = @($TargetObject.Properties);
     }
     foreach ($agentPool in $agentPools) {
-        $Assert.GreaterOrEqual($agentPool, 'maxPods', $Configuration.Azure_AKSNodeMinimumPods)
+        $Assert.GreaterOrEqual($agentPool, 'maxPods', $Configuration.Azure_AKSNodeMinimumMaxPods)
     }
-} -Configure @{ Azure_AKSNodeMinimumPods = 50 }
+} -Configure @{ Azure_AKSNodeMinimumMaxPods = 50 }

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -34,9 +34,12 @@ function global:GetSubResources {
 }
 
 function global:IsAllowedRegion {
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param ()
     process {
-        $region = $Configuration.azureAllowedRegions;
-        foreach ($r in $Configuration.azureAllowedRegions) {
+        $region = @($Configuration.Azure_AllowedRegions);
+        foreach ($r in $Configuration.Azure_AllowedRegions) {
             $region += ($r -replace ' ', '')
         }
         return $TargetObject.Location -in $region;
@@ -84,6 +87,7 @@ function global:HasPeerNetwork {
 
 # Get a sorted list of NSG rules
 function global:GetOrderedNSGRules {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $True)]
         [ValidateSet('Inbound', 'Outbound')]

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -5,8 +5,12 @@
 # Validation rules for Azure resources
 #
 
+if ($Null -ne $Configuration.azureAllowedRegions) {
+    Write-Warning -Message ($LocalizedData.ConfigurationOptionReplaced -f 'azureAllowedRegions', 'Azure_AllowedRegions');
+}
+
 # Synopsis: Resources should be tagged
-Rule 'Azure.Resource.UseTags' -If { (SupportsTags) } -Tag @{ release = 'GA' } {
+Rule 'Azure.Resource.UseTags' -If { SupportsTags } -Tag @{ release = 'GA' } {
     Reason $LocalizedData.ResourceNotTagged
     # List of resource that support tags can be found here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/tag-support
     (Exists 'Tags') -and
@@ -14,6 +18,6 @@ Rule 'Azure.Resource.UseTags' -If { (SupportsTags) } -Tag @{ release = 'GA' } {
 }
 
 # Synopsis: Resources should be deployed to allowed regions
-Rule 'Azure.Resource.AllowedRegions' -If { ($Null -ne $Configuration.azureAllowedRegions) -and (SupportsRegions) } -Tag @{ release = 'GA' } {
+Rule 'Azure.Resource.AllowedRegions' -If { ($Null -ne $Configuration.Azure_AllowedRegions) -and ($Configuration.Azure_AllowedRegions.Length -gt 0) -and (SupportsRegions) } -Tag @{ release = 'GA' } {
     IsAllowedRegion
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Azure.Resource' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.Resource.json';
 
     Context 'Conditions' {
-        $option = New-PSRuleOption -BaselineConfiguration @{ 'azureAllowedRegions' = @('region-A') };
+        $option = New-PSRuleOption -BaselineConfiguration @{ 'Azure_AllowedRegions' = @('region-A') };
         $invokeParams = @{
             Baseline = 'Azure.All'
             Module = 'PSRule.Rules.Azure'
@@ -87,7 +87,7 @@ Describe 'Azure.Resource' {
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Resource.json;
         Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
-        $option = New-PSRuleOption -BaselineConfiguration @{ 'azureAllowedRegions' = @('region-A') };
+        $option = New-PSRuleOption -BaselineConfiguration @{ 'Azure_AllowedRegions' = @('region-A') };
         $invokeParams = @{
             Baseline = 'Azure.All'
             Module = 'PSRule.Rules.Azure'


### PR DESCRIPTION
## PR Summary

- General improvements:
  - **Breaking change**: Renamed configuration options to use a standard prefix. #327
    - Configuration options use the `Azure_` prefix.
    - Update configuration settings to use the new name, old configuration names are ignored.
    - Renamed `minAKSVersion` to `Azure_AKSMinimumVersion`.
    - Renamed `azureAllowedRegions` to `Azure_AllowedRegions`.
    - Added configuration option documentation.

Fixes #327 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
