### PR TITLE
Pre-release v0.11.0-B2004012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.11.0-B2004012 (pre-release)
+
 - New rules:
   - Azure Kubernetes Service:
     - Check AKS nodes use a minimum number of pods. [#274](https://github.com/Microsoft/PSRule.Rules.Azure/issues/274)


### PR DESCRIPTION
## PR Summary

- New rules:
  - Azure Kubernetes Service:
    - Check AKS nodes use a minimum number of pods. #274
- General improvements:
  - **Breaking change**: Renamed configuration options to use a standard prefix. #327
    - Configuration options use the `Azure_` prefix.
    - Update configuration settings to use the new name, old configuration names are ignored.
    - Renamed `minAKSVersion` to `Azure_AKSMinimumVersion`.
    - Renamed `azureAllowedRegions` to `Azure_AllowedRegions`.
    - Added configuration option documentation. See [about_PSRule_Azure_Configuration](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md) for details.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
