### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,32 @@
 
 ## Unreleased
 
+## v0.11.0
+
+What's changed since v0.10.1:
+
+- New rules:
+  - Azure Kubernetes Service:
+    - Check AKS nodes use a minimum number of pods. [#274](https://github.com/Microsoft/PSRule.Rules.Azure/issues/274)
+  - API Management:
+    - Check API Management products require a subscription. [#342](https://github.com/Microsoft/PSRule.Rules.Azure/issues/342)
+    - Check API Management products require approval. [#343](https://github.com/Microsoft/PSRule.Rules.Azure/issues/343)
+    - Check API Management sample products have been removed. [#344](https://github.com/Microsoft/PSRule.Rules.Azure/issues/344)
+    - Check API Management uses a managed identity. [#345](https://github.com/Microsoft/PSRule.Rules.Azure/issues/345)
+    - Check API Management certificates are not expired. [#346](https://github.com/Microsoft/PSRule.Rules.Azure/issues/346)
 - General improvements:
-  - Add name and type bindings for template files. [#353](https://github.com/Microsoft/PSRule.Rules.Azure/issues/353)
+  - Added name and type bindings for template files. [#353](https://github.com/Microsoft/PSRule.Rules.Azure/issues/353)
+  - **Breaking change**: Renamed configuration options to use a standard prefix. [#327](https://github.com/Microsoft/PSRule.Rules.Azure/issues/327)
+    - Configuration options use the `Azure_` prefix.
+    - Update configuration settings to use the new name, old configuration names are ignored.
+    - Renamed `minAKSVersion` to `Azure_AKSMinimumVersion`.
+    - Renamed `azureAllowedRegions` to `Azure_AllowedRegions`.
+    - Added configuration option documentation. See [about_PSRule_Azure_Configuration](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md) for details.
+
+What's changed since pre-release v0.11.0-B2004012:
+
+- General improvements:
+  - Added name and type bindings for template files. [#353](https://github.com/Microsoft/PSRule.Rules.Azure/issues/353)
 
 ## v0.11.0-B2004012 (pre-release)
 


### PR DESCRIPTION
## PR Summary

What's changed since v0.10.1:

- New rules:
  - Azure Kubernetes Service:
    - Check AKS nodes use a minimum number of pods. #274
  - API Management:
    - Check API Management products require a subscription. #342
    - Check API Management products require approval. #343
    - Check API Management sample products have been removed. #344
    - Check API Management uses a managed identity. #345
    - Check API Management certificates are not expired. #346
- General improvements:
  - Added name and type bindings for template files. #353
  - **Breaking change**: Renamed configuration options to use a standard prefix. #327
    - Configuration options use the `Azure_` prefix.
    - Update configuration settings to use the new name, old configuration names are ignored.
    - Renamed `minAKSVersion` to `Azure_AKSMinimumVersion`.
    - Renamed `azureAllowedRegions` to `Azure_AllowedRegions`.
    - Added configuration option documentation. See [about_PSRule_Azure_Configuration](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md) for details.

What's changed since pre-release v0.11.0-B2004012:

- General improvements:
  - Added name and type bindings for template files. #353

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
