### PR TITLE
Add rules for checking common resource names #373

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,19 @@
 ## Unreleased
 
 - New rules:
+  - Azure Kubernetes Service:
+    - Check AKS cluster name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+    - Check AKS cluster DNS prefix requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Container Registry:
+    - Check registry name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - ExpressRoute Gateway:
     - Check ExpressRoute Gateway uses current SKU. [#369](https://github.com/Microsoft/PSRule.Rules.Azure/issues/369)
+  - Front Door:
+    - Check Front Door name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - SignalR Service:
+    - Check SignalR Service name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Virtual Network:
+    - Check VNET name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - VPN Gateway:
     - Check VPN Gateway uses current SKU. [#370](https://github.com/Microsoft/PSRule.Rules.Azure/issues/370)
     - Check VPN Gateway uses active-active configuration. [#371](https://github.com/Microsoft/PSRule.Rules.Azure/issues/371)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,29 @@
     - Check AKS cluster DNS prefix requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - Container Registry:
     - Check registry name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
-  - ExpressRoute Gateway:
-    - Check ExpressRoute Gateway uses current SKU. [#369](https://github.com/Microsoft/PSRule.Rules.Azure/issues/369)
   - Front Door:
     - Check Front Door name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Load Balancer:
+    - Check Load Balancer name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Network Security Group:
+    - Check NSG name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Public IP:
+    - Check Public IP name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Resource Group:
+    - Check Resource Group name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Route table
+    - Check Route table name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - SignalR Service:
     - Check SignalR Service name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Storage:
+    - Check Storage Account name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - Virtual Network:
     - Check VNET name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
-  - VPN Gateway:
+    - Check VNET subnet name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+  - Virtual Network Gateway:
+    - Check VNG name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+    - Check VNG connection name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
+    - Check ExpressRoute Gateway uses current SKU. [#369](https://github.com/Microsoft/PSRule.Rules.Azure/issues/369)
     - Check VPN Gateway uses current SKU. [#370](https://github.com/Microsoft/PSRule.Rules.Azure/issues/370)
     - Check VPN Gateway uses active-active configuration. [#371](https://github.com/Microsoft/PSRule.Rules.Azure/issues/371)
 

--- a/docs/rules/en/Azure.ACR.Name.md
+++ b/docs/rules/en/Azure.ACR.Name.md
@@ -1,0 +1,34 @@
+---
+severity: Awareness
+category: Naming
+resource: Container Registry
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.ACR.Name.md
+---
+
+# Use valid registry names
+
+## SYNOPSIS
+
+Container registry names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for container registry names are:
+
+- Between 5 and 50 characters long.
+- Alphanumerics.
+- Container registry names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet container registry naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if container registry names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.AKS.DNSPrefix.md
+++ b/docs/rules/en/Azure.AKS.DNSPrefix.md
@@ -1,0 +1,25 @@
+---
+severity: Awareness
+category: Naming
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.DNSPrefix.md
+---
+
+# Use valid AKS cluster DNS prefix
+
+## SYNOPSIS
+
+Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements.
+
+## DESCRIPTION
+
+The DNS prefix for AKS clusters has different requirements then the cluster name.
+The requirements for DNS prefixes are:
+
+- Between 1 and 54 characters long.
+- Alphanumerics and hyphens.
+- Start and end with alphanumeric.
+
+## RECOMMENDATION
+
+Consider using a DNS prefix that meets naming requirements.

--- a/docs/rules/en/Azure.AKS.Name.md
+++ b/docs/rules/en/Azure.AKS.Name.md
@@ -1,0 +1,42 @@
+---
+severity: Awareness
+category: Naming
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.Name.md
+---
+
+# Use valid AKS cluster names
+
+## SYNOPSIS
+
+Azure Kubernetes Service (AKS) cluster names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for AKS cluster names are:
+
+- Between 1 and 63 characters long.
+- Alphanumerics, underscores, and hyphens.
+- Start and end with alphanumeric.
+- Cluster names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet AKS cluster naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if cluster names are unique.
+
+Cluster DNS prefix has different naming requirements then cluster name.
+The requirements for DNS prefixes are:
+
+- Between 1 and 54 characters long.
+- Alphanumerics and hyphens.
+- Start and end with alphanumeric.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.FrontDoor.Name.md
+++ b/docs/rules/en/Azure.FrontDoor.Name.md
@@ -1,0 +1,35 @@
+---
+severity: Awareness
+category: Naming
+resource: Front Door
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.FrontDoor.Name.md
+---
+
+# Use valid Front Door names
+
+## SYNOPSIS
+
+Front Door names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Front Door names are:
+
+- Between 5 and 64 characters long.
+- Alphanumerics and hyphens.
+- Start and end with alphanumeric.
+- Front Door names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet Front Door naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Front Door names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.LB.Name.md
+++ b/docs/rules/en/Azure.LB.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Load Balancer
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.LB.Name.md
+---
+
+# Use valid Load Balancer names
+
+## SYNOPSIS
+
+Load Balancer names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Load Balancer names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- Load Balancer names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Load Balancer naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Load Balancer names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.NSG.Name.md
+++ b/docs/rules/en/Azure.NSG.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Network Security Group
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.NSG.Name.md
+---
+
+# Use valid NSG names
+
+## SYNOPSIS
+
+Network Security Group (NSG) names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Network Security Group names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- NSG names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Network Security Group naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Network Security Group names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.PublicIP.Name.md
+++ b/docs/rules/en/Azure.PublicIP.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Public IP address
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.PublicIP.Name.md
+---
+
+# Use valid Public IP names
+
+## SYNOPSIS
+
+Public IP names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Public IP names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- Public IP names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Public IP naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Public IP names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.ResourceGroup.Name.md
+++ b/docs/rules/en/Azure.ResourceGroup.Name.md
@@ -1,0 +1,35 @@
+---
+severity: Awareness
+category: Naming
+resource: Resource Group
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.ResourceGroup.Name.md
+---
+
+# Use valid resource group names
+
+## SYNOPSIS
+
+Resource Group names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Resource Group names are:
+
+- Between 1 and 90 characters long.
+- Alphanumerics, underscores, parentheses, hyphens, periods.
+- Can't end with period.
+- Resource Group names must be unique within a subscription.
+
+## RECOMMENDATION
+
+Consider using names that meet Resource Group naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Resource Group names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.Route.Name.md
+++ b/docs/rules/en/Azure.Route.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Route table
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.Route.Name.md
+---
+
+# Use valid Route table names
+
+## SYNOPSIS
+
+Route table names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Route table names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- Route table names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Route table naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Route table names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.SignalR.Name.md
+++ b/docs/rules/en/Azure.SignalR.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: SignalR Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.SignalR.Name.md
+---
+
+# Use valid SignalR service names
+
+## SYNOPSIS
+
+SignalR service instance names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for SignalR service names are:
+
+- Between 3 and 63 characters long.
+- Alphanumerics and hyphens.
+- Start with letter.
+- End with letter or number.
+- SignalR service names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet SignalR service naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if SignalR service names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.Storage.Name.md
+++ b/docs/rules/en/Azure.Storage.Name.md
@@ -1,0 +1,34 @@
+---
+severity: Awareness
+category: Naming
+resource: Storage Account
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.Storage.Name.md
+---
+
+# Use valid storage account names
+
+## SYNOPSIS
+
+Storage Account names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Storage Account names are:
+
+- Between 3 and 24 characters long.
+- Lowercase letters or numbers.
+- Storage Account names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet Storage Account naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Storage Account names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.VNET.Name.md
+++ b/docs/rules/en/Azure.VNET.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Virtual Network
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNET.Name.md
+---
+
+# Use valid VNET names
+
+## SYNOPSIS
+
+Virtual Network (VNET) names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Virtual Network names are:
+
+- Between 2 and 64 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- VNET names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Virtual Network naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if Virtual Network names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.VNET.SubnetName.md
+++ b/docs/rules/en/Azure.VNET.SubnetName.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Virtual Network
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNET.SubnetName.md
+---
+
+# Use valid subnet names
+
+## SYNOPSIS
+
+Subnet names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for Route table names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- Subnet names must be unique within a virtual network.
+
+## RECOMMENDATION
+
+Consider using names that meet subnet naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if subnet names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.VNG.ConnectionName.md
+++ b/docs/rules/en/Azure.VNG.ConnectionName.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Virtual Network Gateway
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNG.ConnectionName.md
+---
+
+# Use valid connection names
+
+## SYNOPSIS
+
+Virtual Network Gateway (VNG) connection names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for connection names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- Connection names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet connection naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if connection names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.VNG.ERLegacySKU.md
+++ b/docs/rules/en/Azure.VNG.ERLegacySKU.md
@@ -1,8 +1,8 @@
 ---
 severity: Important
 category: Reliability
-resource: ExpressRoute
-online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.ERGateway.LegacySKU.md
+resource: Virtual Network Gateway
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNG.ERLegacySKU.md
 ---
 
 # Migrate from legacy ER gateway SKUs

--- a/docs/rules/en/Azure.VNG.Name.md
+++ b/docs/rules/en/Azure.VNG.Name.md
@@ -1,0 +1,36 @@
+---
+severity: Awareness
+category: Naming
+resource: Virtual Network Gateway
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNG.Name.md
+---
+
+# Use valid VNG names
+
+## SYNOPSIS
+
+Virtual Network Gateway (VNG) names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for VNG names are:
+
+- Between 1 and 80 characters long.
+- Alphanumerics, underscores, periods, and hyphens.
+- Start with alphanumeric.
+- End alphanumeric or underscore.
+- VNG names must be unique within a resource group.
+
+## RECOMMENDATION
+
+Consider using names that meet Virtual Network Gateway (VNG) naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if VNG names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)

--- a/docs/rules/en/Azure.VNG.VPNActiveActive.md
+++ b/docs/rules/en/Azure.VNG.VPNActiveActive.md
@@ -1,8 +1,8 @@
 ---
 severity: Important
 category: Reliability
-resource: VPN Gateway
-online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VPNGateway.ActiveActive.md
+resource: Virtual Network Gateway
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNG.VPNActiveActive.md
 ---
 
 # Use Active-Active VPN gateways

--- a/docs/rules/en/Azure.VNG.VPNLegacySKU.md
+++ b/docs/rules/en/Azure.VNG.VPNLegacySKU.md
@@ -1,8 +1,8 @@
 ---
 severity: Important
 category: Reliability
-resource: VPN Gateway
-online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VPNGateway.LegacySKU.md
+resource: Virtual Network Gateway
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.VNG.VPNLegacySKU.md
 ---
 
 # Migrate from legacy VPN gateway SKUs

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -21,6 +21,17 @@ Name | Synopsis | Severity
 [Azure.KeyVault.SoftDelete](Azure.KeyVault.SoftDelete.md) | Enable Soft Delete on Key Vaults to protect vaults and vault items from accidental deletion. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 
+### Naming
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.ACR.Name](Azure.ACR.Name.md) | Container registry names should meet naming requirements. | Awareness
+[Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness
+[Azure.FrontDoor.Name](Azure.FrontDoor.Name.md) | Front Door names should meet naming requirements. | Awareness
+[Azure.SignalR.Name](Azure.SignalR.Name.md) | SignalR service instance names should meet naming requirements. | Awareness
+[Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
+
 ### Operations management
 
 Name | Synopsis | Severity

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -29,8 +29,17 @@ Name | Synopsis | Severity
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness
 [Azure.FrontDoor.Name](Azure.FrontDoor.Name.md) | Front Door names should meet naming requirements. | Awareness
+[Azure.LB.Name](Azure.LB.Name.md) | Load Balancer names should meet naming requirements. | Awareness
+[Azure.NSG.Name](Azure.NSG.Name.md) | Network Security Group (NSG) names should meet naming requirements. | Awareness
+[Azure.PublicIP.Name](Azure.PublicIP.Name.md) | Public IP names should meet naming requirements. | Awareness
+[Azure.ResourceGroup.Name](Azure.ResourceGroup.Name.md) | Resource Group names should meet naming requirements. | Awareness
+[Azure.Route.Name](Azure.Route.Name.md) | Route table names should meet naming requirements. | Awareness
 [Azure.SignalR.Name](Azure.SignalR.Name.md) | SignalR service instance names should meet naming requirements. | Awareness
+[Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
+[Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
+[Azure.VNG.ConnectionName](Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
+[Azure.VNG.Name](Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness
 
 ### Operations management
 
@@ -79,7 +88,6 @@ Name | Synopsis | Severity
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
 [Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | Use an App Service Plan with at least two (2) instances. | Single point of failure
-[Azure.ERGateway.LegacySKU](Azure.ERGateway.LegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
 [Azure.Monitor.ServiceHealth](Azure.Monitor.ServiceHealth.md) | Configure Service Health alerts to notify administrators. | Important
 [Azure.NSG.DenyAllInbound](Azure.NSG.DenyAllInbound.md) | Avoid denying all inbound traffic. | Important
 [Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Single point of failure
@@ -90,8 +98,9 @@ Name | Synopsis | Severity
 [Azure.VM.UseManagedDisks](Azure.VM.UseManagedDisks.md) | Virtual machines (VMs) should use managed disks. | Single point of failure
 [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
 [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Single point of failure
-[Azure.VPNGateway.ActiveActive](Azure.VPNGateway.ActiveActive.md) | Use VPN gateways configured to operate in an Active-Active configuration to reduce connectivity downtime. | Important
-[Azure.VPNGateway.LegacySKU](Azure.VPNGateway.LegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of VPN gateways. | Important
+[Azure.VNG.ERLegacySKU](Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
+[Azure.VNG.VPNActiveActive](Azure.VNG.VPNActiveActive.md) | Use VPN gateways configured to operate in an Active-Active configuration to reduce connectivity downtime. | Important
+[Azure.VNG.VPNLegacySKU](Azure.VNG.VPNLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of VPN gateways. | Important
 
 ### Resiliency
 

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -79,7 +79,9 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
+[Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness
 [Azure.AKS.NetworkPolicy](Azure.AKS.NetworkPolicy.md) | Deploy AKS clusters with Azure Network Policies enabled. | Important
 [Azure.AKS.NodeMinPods](Azure.AKS.NodeMinPods.md) | Azure Kubernetes Cluster (AKS) nodes should use a minimum number of pods. | Important
 [Azure.AKS.PodSecurityPolicy](Azure.AKS.PodSecurityPolicy.md) | Configure AKS non-production clusters to use Pod Security Policies (Preview). | Important
@@ -104,6 +106,7 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.AdminUser](Azure.ACR.AdminUser.md) | Use Azure AD accounts instead of using the registry admin user. | Critical
 [Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments. | Important
+[Azure.ACR.Name](Azure.ACR.Name.md) | Container registry names should meet naming requirements. | Awareness
 
 ### Content Delivery Network
 
@@ -135,6 +138,7 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.FrontDoor.Logs](Azure.FrontDoor.Logs.md) | Audit and monitor access through Front Door. | Important
 [Azure.FrontDoor.MinTLS](Azure.FrontDoor.MinTLS.md) | Front Door should reject TLS versions older then 1.2. | Critical
+[Azure.FrontDoor.Name](Azure.FrontDoor.Name.md) | Front Door names should meet naming requirements. | Awareness
 [Azure.FrontDoor.State](Azure.FrontDoor.State.md) | Enable Azure Front Door instance. | Important
 [Azure.FrontDoor.UseWAF](Azure.FrontDoor.UseWAF.md) | Enable Web Application Firewall (WAF) policies on each Front Door endpoint. | Critical
 [Azure.FrontDoor.WAF.Enabled](Azure.FrontDoor.WAF.Enabled.md) | Front Door Web Application Firewall (WAF) policy must be enabled to protect back end resources. | Critical
@@ -196,6 +200,12 @@ Name | Synopsis | Severity
 [Azure.SecurityCenter.Contact](Azure.SecurityCenter.Contact.md) | Security Center email and phone contact details should be set. | Important
 [Azure.SecurityCenter.Provisioning](Azure.SecurityCenter.Provisioning.md) | Enable auto-provisioning on to improve Azure Security Center insights. | Important
 
+### SignalR Service
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.SignalR.Name](Azure.SignalR.Name.md) | SignalR service instance names should meet naming requirements. | Awareness
+
 ### Storage
 
 Name | Synopsis | Severity
@@ -255,6 +265,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.VNET.LocalDNS](Azure.VNET.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Important
+[Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Single point of failure
 [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -120,12 +120,6 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
 
-### ExpressRoute
-
-Name | Synopsis | Severity
----- | -------- | --------
-[Azure.ERGateway.LegacySKU](Azure.ERGateway.LegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
-
 ### Firewall
 
 Name | Synopsis | Severity
@@ -157,6 +151,7 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.LB.Name](Azure.LB.Name.md) | Load Balancer names should meet naming requirements. | Awareness
 [Azure.LB.Probe](Azure.LB.Probe.md) | Use a specific probe for web protocols. | Important
 
 ### Monitor
@@ -173,6 +168,7 @@ Name | Synopsis | Severity
 [Azure.NSG.Associated](Azure.NSG.Associated.md) | Network Security Groups (NSGs) should be associated. | Awareness
 [Azure.NSG.DenyAllInbound](Azure.NSG.DenyAllInbound.md) | Avoid denying all inbound traffic. | Important
 [Azure.NSG.LateralTraversal](Azure.NSG.LateralTraversal.md) | Deny outbound management connections from non-management hosts. | Important
+[Azure.NSG.Name](Azure.NSG.Name.md) | Network Security Group (NSG) names should meet naming requirements. | Awareness
 
 ### Policy
 
@@ -185,6 +181,7 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP address should be attached. | Awareness
+[Azure.PublicIP.Name](Azure.PublicIP.Name.md) | Public IP names should meet naming requirements. | Awareness
 
 ### Redis
 
@@ -192,6 +189,18 @@ Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.Redis.MinTLS](Azure.Redis.MinTLS.md) | Redis Cache should reject TLS versions older then 1.2. | Critical
 [Azure.Redis.NonSslPort](Azure.Redis.NonSslPort.md) | Redis Cache should only accept secure connections. | Critical
+
+### Resource Group
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.ResourceGroup.Name](Azure.ResourceGroup.Name.md) | Resource Group names should meet naming requirements. | Awareness
+
+### Route table
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.Route.Name](Azure.Route.Name.md) | Route table names should meet naming requirements. | Awareness
 
 ### Security Center
 
@@ -216,6 +225,7 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
@@ -268,11 +278,15 @@ Name | Synopsis | Severity
 [Azure.VNET.Name](Azure.VNET.Name.md) | Virtual Network (VNET) names should meet naming requirements. | Awareness
 [Azure.VNET.PeerState](Azure.VNET.PeerState.md) | VNET peering connections must be connected. | Important
 [Azure.VNET.SingleDNS](Azure.VNET.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Single point of failure
+[Azure.VNET.SubnetName](Azure.VNET.SubnetName.md) | Subnet names should meet naming requirements. | Awareness
 [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
 
-### VPN Gateway
+### Virtual Network Gateway
 
 Name | Synopsis | Severity
 ---- | -------- | --------
-[Azure.VPNGateway.ActiveActive](Azure.VPNGateway.ActiveActive.md) | Use VPN gateways configured to operate in an Active-Active configuration to reduce connectivity downtime. | Important
-[Azure.VPNGateway.LegacySKU](Azure.VPNGateway.LegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of VPN gateways. | Important
+[Azure.VNG.ConnectionName](Azure.VNG.ConnectionName.md) | Virtual Network Gateway (VNG) connection names should meet naming requirements. | Awareness
+[Azure.VNG.ERLegacySKU](Azure.VNG.ERLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of ExpressRoute (ER) gateways. | Important
+[Azure.VNG.Name](Azure.VNG.Name.md) | Virtual Network Gateway (VNG) names should meet naming requirements. | Awareness
+[Azure.VNG.VPNActiveActive](Azure.VNG.VPNActiveActive.md) | Use VPN gateways configured to operate in an Active-Active configuration to reduce connectivity downtime. | Important
+[Azure.VNG.VPNLegacySKU](Azure.VNG.VPNLegacySKU.md) | Migrate from legacy SKUs to improve reliability and performance of VPN gateways. | Important

--- a/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.ACR.Rule.ps1
@@ -14,3 +14,15 @@ Rule 'Azure.ACR.AdminUser' -Type 'Microsoft.ContainerRegistry/registries' -Tag @
 Rule 'Azure.ACR.MinSku' -Type 'Microsoft.ContainerRegistry/registries' -Tag @{ release = 'GA' } {
     Within 'Sku.tier' 'Premium', 'Standard'
 }
+
+# Synopsis: Use ACR naming requirements
+Rule 'Azure.ACR.Name' -Type 'Microsoft.ContainerRegistry/registries' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerregistry
+
+    # Between 5 and 50 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 5)
+    $Assert.LessOrEqual($TargetObject, 'Name', 50)
+
+    # Alphanumerics
+    Match 'Name' '^[a-zA-Z0-9]*$'
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -89,3 +89,27 @@ Rule 'Azure.AKS.NodeMinPods' -Type 'Microsoft.ContainerService/managedClusters',
         $Assert.GreaterOrEqual($agentPool, 'maxPods', $Configuration.Azure_AKSNodeMinimumMaxPods)
     }
 } -Configure @{ Azure_AKSNodeMinimumMaxPods = 50 }
+
+# Synopsis: Use AKS naming requirements
+Rule 'Azure.AKS.Name' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerservice
+
+    # Between 1 and 63 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
+    $Assert.LessOrEqual($TargetObject, 'Name', 63)
+
+    # Alphanumerics, underscores, and hyphens
+    # Start and end with alphanumeric
+    Match 'Name' '^[A-Za-z0-9](-|\w)*[A-Za-z0-9]$'
+}
+
+# Synopsis: Use AKS naming requirements for DNS prefix
+Rule 'Azure.AKS.DNSPrefix' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+    # Between 1 and 54 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Properties.dnsPrefix', 1)
+    $Assert.LessOrEqual($TargetObject, 'Properties.dnsPrefix', 54)
+
+    # Alphanumerics and hyphens
+    # Start and end with alphanumeric
+    Match 'Properties.dnsPrefix' '^[A-Za-z0-9]((-|[A-Za-z0-9]){0,}[A-Za-z0-9]){0,}$'
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.FrontDoor.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.FrontDoor.Rule.ps1
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Validation rules for Front Door
+#
+
+#region Front Door
+
+# Synopsis: Front Door instance should be enabled
+Rule 'Azure.FrontDoor.State' -Type 'Microsoft.Network/frontDoors' -Tag @{ release = 'GA' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.enabledState', 'Enabled');
+}
+
+# Synopsis: Use a minimum of TLS 1.2
+Rule 'Azure.FrontDoor.MinTLS' -Type 'Microsoft.Network/frontDoors', 'Microsoft.Network/frontDoors/frontendEndpoints' -Tag @{ release = 'GA' } {
+    $endpoints = @($TargetObject);
+    if ($PSRule.TargetType -eq 'Microsoft.Network/frontDoors') {
+        $endpoints = @($TargetObject.Properties.frontendEndpoints);
+    }
+    foreach ($endpoint in $endpoints) {
+        $Assert.HasDefaultValue($endpoint, 'properties.customHttpsConfiguration.minimumTlsVersion', '1.2');
+    }
+    # properties.frontendEndpoints[].properties.customHttpsConfiguration.minimumTlsVersion
+}
+
+# Synopsis: Use diagnostics to audit Front Door access
+Rule 'Azure.FrontDoor.Logs' -Type 'Microsoft.Network/frontDoors' -Tag @{ release = 'GA' } {
+    Reason $LocalizedData.DiagnosticSettingsNotConfigured;
+    $diagnostics = @(GetSubResources -ResourceType 'microsoft.insights/diagnosticSettings', 'Microsoft.Network/frontDoors/providers/diagnosticSettings');
+    $logCategories = @($diagnostics | ForEach-Object {
+        foreach ($log in $_.Properties.logs) {
+            if ($log.category -eq 'FrontdoorAccessLog' -and $log.enabled -eq $True) {
+                $log;
+            }
+        }
+    });
+    $Null -ne $logCategories -and $logCategories.Length -gt 0;
+}
+
+# Synopsis: Enable WAF policy of each endpoint
+Rule 'Azure.FrontDoor.UseWAF' -Type 'Microsoft.Network/frontDoors', 'Microsoft.Network/frontDoors/frontendEndpoints' -Tag @{ release = 'GA' } {
+    $endpoints = @($TargetObject);
+    if ($PSRule.TargetType -eq 'Microsoft.Network/frontDoors') {
+        $endpoints = @($TargetObject.Properties.frontendEndpoints);
+    }
+    foreach ($endpoint in $endpoints) {
+        $Assert.HasFieldValue($endpoint, 'properties.webApplicationFirewallPolicyLink.id');
+    }
+}
+
+# Synopsis: Use Front Door naming requirements
+Rule 'Azure.FrontDoor.Name' -Type 'Microsoft.Network/frontDoors' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork
+
+    # Between 5 and 64 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 5)
+    $Assert.LessOrEqual($TargetObject, 'Name', 64)
+
+    # Alphanumerics and hyphens
+    # Start and end with alphanumeric
+    Match 'Name' '^[A-Za-z](-|[A-Za-z0-9])*[A-Za-z0-9]$'
+}
+
+# Synopsis: Use Front Door WAF policy in prevention mode
+Rule 'Azure.FrontDoor.WAF.Mode' -Type 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies' -Tag @{ release = 'GA' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.policySettings.mode', 'Prevention');
+}
+
+# Synopsis: Enable Front Door WAF policy
+Rule 'Azure.FrontDoor.WAF.Enabled' -Type 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies' -Tag @{ release = 'GA' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.policySettings.enabledState', 'Enabled');
+}
+
+#endregion Front Door

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -21,3 +21,16 @@ Rule 'Azure.Resource.UseTags' -If { SupportsTags } -Tag @{ release = 'GA' } {
 Rule 'Azure.Resource.AllowedRegions' -If { ($Null -ne $Configuration.Azure_AllowedRegions) -and ($Configuration.Azure_AllowedRegions.Length -gt 0) -and (SupportsRegions) } -Tag @{ release = 'GA' } {
     IsAllowedRegion
 }
+
+# Synopsis: Use Resource Group naming requirements
+Rule 'Azure.ResourceGroup.Name' -Type 'Microsoft.Resources/resourceGroups' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftresources
+
+    # Between 1 and 90 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
+    $Assert.LessOrEqual($TargetObject, 'Name', 90)
+
+    # Alphanumerics, underscores, parentheses, hyphens, periods
+    # Can't end with period.
+    Match 'Name' '^[-\w\._\(\)]*[-\w_\(\)]$'
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.SignalR.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SignalR.Rule.ps1
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Validation rules for SignalR service
+#
+
+# Synopsis: Use SignalR naming requirements
+Rule 'Azure.SignalR.Name' -Type 'Microsoft.SignalRService/signalR' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftsignalrservice
+
+    # Between 3 and 63 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 3)
+    $Assert.LessOrEqual($TargetObject, 'Name', 63)
+
+    # Alphanumerics and hyphens
+    # Start with letter
+    # End with letter or number
+    Match 'Name' '^[A-Za-z](-|[A-Za-z0-9])*[A-Za-z0-9]$'
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
@@ -42,3 +42,15 @@ Rule 'Azure.Storage.BlobAccessType' -Type 'Microsoft.Storage/storageAccounts', '
             WithReason(($LocalizedData.PublicAccessStorageContainer -f $container.name, $container.Properties.publicAccess), $True);
     }
 }
+
+# Synopsis: Use Storage naming requirements
+Rule 'Azure.Storage.Name' -Type 'Microsoft.Storage/storageAccounts' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
+
+    # Between 3 and 24 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 3)
+    $Assert.LessOrEqual($TargetObject, 'Name', 24)
+
+    # Lowercase letters and numbers
+    Match 'Name' '^[a-z0-9]{3,24}$' -CaseSensitive
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -69,6 +69,20 @@ Rule 'Azure.VNET.PeerState' -If { (HasPeerNetwork) } -Tag @{ release = 'GA' } {
     }
 }
 
+# Synopsis: Use VNET naming requirements
+Rule 'Azure.VNET.Name' -Type 'Microsoft.Network/virtualNetworks' -Tag @{ release = 'GA' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork
+
+    # Between 2 and 64 characters long
+    $Assert.GreaterOrEqual($TargetObject, 'Name', 2)
+    $Assert.LessOrEqual($TargetObject, 'Name', 64)
+
+    # Alphanumerics, underscores, periods, and hyphens
+    # Start with alphanumeric
+    # End alphanumeric or underscore
+    Match 'Name' '^[A-Za-z0-9](-|\w|\.){0,}\w$'
+}
+
 #endregion Virtual Network
 
 #region Network Security Group

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -221,62 +221,6 @@ Rule 'Azure.Firewall.Mode' -Type 'Microsoft.Network/azureFirewalls' -Tag @{ rele
 
 #endregion Azure Firewall
 
-#region Front Door
-
-# Synopsis: Front Door instance should be enabled
-Rule 'Azure.FrontDoor.State' -Type 'Microsoft.Network/frontDoors' -Tag @{ release = 'GA' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.enabledState', 'Enabled');
-}
-
-# Synopsis: Use a minimum of TLS 1.2
-Rule 'Azure.FrontDoor.MinTLS' -Type 'Microsoft.Network/frontDoors', 'Microsoft.Network/frontDoors/frontendEndpoints' -Tag @{ release = 'GA' } {
-    $endpoints = @($TargetObject);
-    if ($PSRule.TargetType -eq 'Microsoft.Network/frontDoors') {
-        $endpoints = @($TargetObject.Properties.frontendEndpoints);
-    }
-    foreach ($endpoint in $endpoints) {
-        $Assert.HasDefaultValue($endpoint, 'properties.customHttpsConfiguration.minimumTlsVersion', '1.2');
-    }
-    # properties.frontendEndpoints[].properties.customHttpsConfiguration.minimumTlsVersion
-}
-
-# Synopsis: Use diagnostics to audit Front Door access
-Rule 'Azure.FrontDoor.Logs' -Type 'Microsoft.Network/frontDoors' -Tag @{ release = 'GA' } {
-    Reason $LocalizedData.DiagnosticSettingsNotConfigured;
-    $diagnostics = @(GetSubResources -ResourceType 'microsoft.insights/diagnosticSettings', 'Microsoft.Network/frontDoors/providers/diagnosticSettings');
-    $logCategories = @($diagnostics | ForEach-Object {
-        foreach ($log in $_.Properties.logs) {
-            if ($log.category -eq 'FrontdoorAccessLog' -and $log.enabled -eq $True) {
-                $log;
-            }
-        }
-    });
-    $Null -ne $logCategories -and $logCategories.Length -gt 0;
-}
-
-# Synopsis: Enable WAF policy of each endpoint
-Rule 'Azure.FrontDoor.UseWAF' -Type 'Microsoft.Network/frontDoors', 'Microsoft.Network/frontDoors/frontendEndpoints' -Tag @{ release = 'GA' } {
-    $endpoints = @($TargetObject);
-    if ($PSRule.TargetType -eq 'Microsoft.Network/frontDoors') {
-        $endpoints = @($TargetObject.Properties.frontendEndpoints);
-    }
-    foreach ($endpoint in $endpoints) {
-        $Assert.HasFieldValue($endpoint, 'properties.webApplicationFirewallPolicyLink.id');
-    }
-}
-
-# Synopsis: Use Front Door WAF policy in prevention mode
-Rule 'Azure.FrontDoor.WAF.Mode' -Type 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies' -Tag @{ release = 'GA' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.policySettings.mode', 'Prevention');
-}
-
-# Synopsis: Enable Front Door WAF policy
-Rule 'Azure.FrontDoor.WAF.Enabled' -Type 'Microsoft.Network/frontdoorwebapplicationfirewallpolicies' -Tag @{ release = 'GA' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.policySettings.enabledState', 'Enabled');
-}
-
-#endregion Front Door
-
 #region VPN Gateways
 
 # Synopsis: Migrate from legacy VPN gateway SKUs

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -23,7 +23,7 @@ $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
-Describe 'Azure.ACR' {
+Describe 'Azure.ACR' -Tag 'ACR' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.ACR.json';
 
     Context 'Conditions' {
@@ -65,6 +65,52 @@ Describe 'Azure.ACR' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'registry-B';
+        }
+    }
+
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'registry1'
+            'REGISTRY001'
+        )
+        $invalidNames = @(
+            '_registry1'
+            '-registry1'
+            'registry1_'
+            'registry1-'
+            'registry-1'
+            'acr1'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.ContainerRegistry/registries'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.ACR.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -164,6 +164,105 @@ Describe 'Azure.AKS' -Tag AKS {
         }
     }
 
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'cluster1'
+            'CLUSTER-1'
+            'cluster_1'
+            '1-cluster'
+        )
+        $invalidNames = @(
+            '_cluster1'
+            '-cluster1'
+            'cluster1_'
+            'cluster1-'
+            'cluster.1'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.ContainerService/managedClusters'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AKS.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AKS.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'DNS prefix' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'cluster1'
+            'CLUSTER-1'
+            '1-cluster'
+        )
+        $invalidNames = @(
+            '_cluster1'
+            '-cluster1'
+            'cluster1_'
+            'cluster1-'
+            'cluster_1'
+            'cluster.1'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            Properties = [PSCustomObject]@{
+                DNSPrefix = ''
+            }
+            ResourceType = 'Microsoft.ContainerService/managedClusters'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $testObject.Properties.DNSPrefix = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AKS.DNSPrefix';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $testObject.Properties.DNSPrefix = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.AKS.DNSPrefix';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
     Context 'With Template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.AKS.Template.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AKS.json;

--- a/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for Azure Front Door rules
+#
+
+[CmdletBinding()]
+param (
+
+)
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+if ($Env:SYSTEM_DEBUG -eq 'true') {
+    $VerbosePreference = 'Continue';
+}
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
+    $dataPath = Join-Path -Path $here -ChildPath 'Resources.FrontDoor.json';
+
+    Context 'Conditions' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $result = Invoke-PSRule @invokeParams -InputPath $dataPath -Outcome All;
+
+        It 'Azure.FrontDoor.State' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.State' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-B', 'frontdoor-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A';
+        }
+
+        It 'Azure.FrontDoor.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+        }
+
+        It 'Azure.FrontDoor.Logs' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.Logs' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+        }
+
+        It 'Azure.FrontDoor.UseWAF' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.UseWAF' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A', 'frontdoor-C';
+        }
+
+        It 'Azure.FrontDoor.WAF.Mode' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.WAF.Mode' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-waf-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-waf-A';
+        }
+
+        It 'Azure.FrontDoor.WAF.Enabled' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.WAF.Enabled' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-waf-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'frontdoor-waf-A';
+        }
+    }
+
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'frontdoor1'
+            'FRONTDOOR-1'
+        )
+        $invalidNames = @(
+            '_frontdoor1'
+            '-frontdoor1'
+            'frontdoor.1'
+            'frontdoor1_'
+            'frontdoor1-'
+            'door'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.Network/frontDoors'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.FrontDoor.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.FrontDoor.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'With template' {
+        $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template3.json';
+        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.FrontDoor.json;
+        Export-AzTemplateRuleData -TemplateFile $templatePath -OutputPath $outputFile;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+
+        It 'Azure.FrontDoor.State' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.State' };
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A';
+        }
+
+        It 'Azure.FrontDoor.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.MinTLS' };
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A';
+        }
+
+        It 'Azure.FrontDoor.Logs' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.FrontDoor.Logs' };
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'frontdoor-A';
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SignalR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SignalR.Tests.ps1
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for Azure SignalR rules
+#
+
+[CmdletBinding()]
+param (
+
+)
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+if ($Env:SYSTEM_DEBUG -eq 'true') {
+    $VerbosePreference = 'Continue';
+}
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+Describe 'Azure.SignalR' -Tag 'SignalR' {
+    # $dataPath = Join-Path -Path $here -ChildPath 'Resources.SignalR.json';
+
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'service1'
+            'SERVICE-1'
+        )
+        $invalidNames = @(
+            '_service1'
+            '-service1'
+            '1service'
+            'se'
+            's'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.SignalRService/signalR'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.SignalR.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 # Setup error handling
 $ErrorActionPreference = 'Stop';
@@ -125,6 +123,50 @@ Describe 'Azure.Storage' -Tag Storage {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
             $ruleResult.TargetName | Should -Be 'storage-A', 'storage-C', 'storage-D';
+        }
+    }
+
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'storage1'
+            '1storage'
+        )
+        $invalidNames = @(
+            'Storage1'
+            'storage-001'
+            'storage_001'
+            's'
+            'storage.1'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.Storage/storageAccounts'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.Storage.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.Storage.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -108,6 +108,50 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
         }
     }
 
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'vnet-001'
+            'vnet-001_'
+            'VNET.001'
+        )
+        $invalidNames = @(
+            '_vnet-001'
+            '-vnet-001'
+            'v'
+            'vnet-001.'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.Network/virtualNetworks'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.VNET.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.VNET.Name';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
     Context 'With Template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';


### PR DESCRIPTION
## PR Summary

- Check AKS cluster name requirements.
- Check AKS cluster DNS prefix requirements.
- Check registry name requirements.
- Check Front Door name requirements.
- Check SignalR Service name requirements.
- Check VNET and subnet name requirements. 
- Check Load Balancer name requirements.
- Check NSG name requirements.
- Check Route table name requirements.
- Check Storage Account name requirements.
- Check Virtual Network Gateway and connection name requirements.
- Renamed VNG rules to `Azure.VNG.VPNActiveActive`, `Azure.VNG.VPNLegacySKU`, `Azure.VNG.ERLegacySKU`.

Fixes #373

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
