### PR TITLE
Fix subnet sub-resource name with slash #381

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - SQL Database:
     - Check SQL Database uses TDE. [#379](https://github.com/Microsoft/PSRule.Rules.Azure/issues/379)
     - Check SQL Database uses AAD authentication. [#378](https://github.com/Microsoft/PSRule.Rules.Azure/issues/378)
+- Bug fixes:
+  - Fixed handling of subnet sub-resource name with slash. [#381](https://github.com/Microsoft/PSRule.Rules.Azure/issues/381)
 
 ## v0.12.0-B2005019 (pre-release)
 

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -77,10 +77,9 @@ Rule 'Azure.VNET.Name' -Type 'Microsoft.Network/virtualNetworks' -Tag @{ release
     $Assert.GreaterOrEqual($TargetObject, 'Name', 2)
     $Assert.LessOrEqual($TargetObject, 'Name', 64)
 
-    # Alphanumerics, underscores, periods, and hyphens
-    # Start with alphanumeric
-    # End alphanumeric or underscore
-    Match 'Name' '^[A-Za-z0-9](-|\w|\.){0,}\w$'
+    # Alphanumerics, underscores, periods, and hyphens.
+    # Start with alphanumeric. End alphanumeric or underscore.
+    Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){1,63}$'
 }
 
 # Synopsis: Use subnets naming requirements
@@ -89,33 +88,26 @@ Rule 'Azure.VNET.SubnetName' -Type 'Microsoft.Network/virtualNetworks', 'Microso
 
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
         foreach ($subnet in $TargetObject.Properties.subnets) {
-            if ($subnet.name -eq 'GatewaySubnet') {
-                $Assert.Pass();
-            }
-            else {
-                # Between 1 and 80 characters long
-                $Assert.GreaterOrEqual($subnet, 'Name', 1)
-                $Assert.LessOrEqual($subnet, 'Name', 80)
-
-                # Alphanumerics, underscores, periods, and hyphens.
-                # Start with alphanumeric. End alphanumeric or underscore.
-                $subnet | Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
-            }
-        }
-    }
-    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets') {
-        if ($PSRule.TargetName -eq 'GatewaySubnet') {
-            $Assert.Pass();
-        }
-        else {
             # Between 1 and 80 characters long
-            $Assert.GreaterOrEqual($TargetObject, 'Name', 1)
-            $Assert.LessOrEqual($TargetObject, 'Name', 80)
+            $Assert.GreaterOrEqual($subnet, 'Name', 1)
+            $Assert.LessOrEqual($subnet, 'Name', 80)
 
             # Alphanumerics, underscores, periods, and hyphens.
             # Start with alphanumeric. End alphanumeric or underscore.
-            $TargetObject | Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
+            $subnet | Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
         }
+    }
+    elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets') {
+        $nameParts = $PSRule.TargetName.Split('/');
+        $name = $nameParts[-1];
+
+        # Between 1 and 80 characters long
+        $Assert.GreaterOrEqual($name, '.', 1)
+        $Assert.LessOrEqual($name, '.', 80)
+
+        # Alphanumerics, underscores, periods, and hyphens.
+        # Start with alphanumeric. End alphanumeric or underscore.
+        $name | Match '.' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -165,6 +165,7 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             'snet-001_'
             'SNET.001'
             's'
+            'vnet-001/GatewaySubnet'
         )
         $invalidNames = @(
             '_snet-001'


### PR DESCRIPTION
## PR Summary

- Fixed handling of subnet sub-resource name with slash. #381

Fixes #381 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [ ] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
