### PR TITLE
Fixed subnet name check for VNET with no subnets #386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed subnet name check for VNET with no subnets. [#386](https://github.com/Microsoft/PSRule.Rules.Azure/issues/386)
+
 ## v0.12.0
 
 What's changed since v0.11.0:

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -85,16 +85,21 @@ Rule 'Azure.VNET.Name' -Type 'Microsoft.Network/virtualNetworks' -Tag @{ release
 # Synopsis: Use subnets naming requirements
 Rule 'Azure.VNET.SubnetName' -Type 'Microsoft.Network/virtualNetworks', 'Microsoft.Network/virtualNetworks/subnets' -Tag @{ release = 'GA' } {
     # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork
-
     if ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks') {
-        foreach ($subnet in $TargetObject.Properties.subnets) {
-            # Between 1 and 80 characters long
-            $Assert.GreaterOrEqual($subnet, 'Name', 1)
-            $Assert.LessOrEqual($subnet, 'Name', 80)
-
-            # Alphanumerics, underscores, periods, and hyphens.
-            # Start with alphanumeric. End alphanumeric or underscore.
-            $subnet | Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
+        $subnets = @($TargetObject.Properties.subnets)
+        if ($subnets.Length -eq 0) {
+            $Assert.Pass();
+        }
+        else {
+            foreach ($subnet in $subnets) {
+                # Between 1 and 80 characters long
+                $Assert.GreaterOrEqual($subnet, 'Name', 1)
+                $Assert.LessOrEqual($subnet, 'Name', 80)
+    
+                # Alphanumerics, underscores, periods, and hyphens.
+                # Start with alphanumeric. End alphanumeric or underscore.
+                $subnet | Match 'Name' '^[A-Za-z0-9]((-|\.)*\w){0,79}$'
+            }
         }
     }
     elseif ($PSRule.TargetType -eq 'Microsoft.Network/virtualNetworks/subnets') {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -49,8 +49,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -BeIn 'vnet-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-E';
         }
 
         It 'Azure.VNET.SingleDNS' {
@@ -65,8 +65,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C', 'vnet-D';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C', 'vnet-D', 'vnet-E';
         }
 
         It 'Azure.VNET.LocalDNS' {
@@ -75,8 +75,8 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-D';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-D', 'vnet-E';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -103,8 +103,36 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' -and $_.TargetObject.ResourceType -eq 'Microsoft.Network/virtualNetworks' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'vnet-D', 'vnet-E';
+        }
+
+        It 'Azure.VNET.Name' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VNET.Name' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E';
+        }
+
+        It 'Azure.VNET.SubnetName' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VNET.SubnetName' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'vnet-A', 'vnet-B', 'vnet-C', 'vnet-D', 'vnet-E';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -516,6 +516,36 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-E",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-E",
+        "Location": "region",
+        "ResourceName": "vnet-E",
+        "Name": "vnet-E",
+        "Properties": {
+            "addressSpace": {
+                "addressPrefixes": [
+                    "10.5.0.0/24"
+                ]
+            },
+            "dhcpOptions": {
+                "dnsServers": [
+                    "10.99.0.36",
+                    "10.99.0.37"
+                ]
+            },
+            "subnets": [
+            ],
+            "virtualNetworkPeerings": [],
+            "enableDdosProtection": false,
+            "enableVmProtection": false
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/virtualNetworks",
+        "ResourceType": "Microsoft.Network/virtualNetworks",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Location": "region",


### PR DESCRIPTION
## PR Summary

- Fixed subnet name check for VNET with no subnets. #386

Fixes #386 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
