### PR TITLE
Added new AKS rules #334 #333 #405

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- New rules:
+  - Azure Kubernetes Service:
+    - Check AKS clusters use a Standard load balancer SKU. [#334](https://github.com/Microsoft/PSRule.Rules.Azure/issues/334)
+    - Check AKS clusters use Managed Identities for cluster infrastructure. [#333](https://github.com/Microsoft/PSRule.Rules.Azure/issues/333)
+    - Check AKS clusters use Azure Policy add-on (preview). [#405](https://github.com/Microsoft/PSRule.Rules.Azure/issues/405)
+
 ## v0.13.0-B2006003 (pre-release)
 
 - Updated rules:

--- a/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
+++ b/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
@@ -1,0 +1,37 @@
+---
+severity: Important
+category: Security configuration
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
+---
+
+# Use Azure Policy add-on with AKS clusters
+
+## SYNOPSIS
+
+Configure Azure Kubernetes Cluster (AKS) clusters to use Azure Policy add-on for Kubernetes (Preview).
+
+## DESCRIPTION
+
+AKS clusters support integration with Azure Policy using an Open Policy Agent (OPA).
+Azure Policy integration is provided by an optional add-on that can be enabled on AKS clusters.
+Once enabled and Azure policies assigned, AKS clusters will enforce the configured constraints.
+
+Examples of policies include:
+
+- Enforce HTTPS ingress in Kubernetes cluster
+- Do not allow privileged containers in Kubernetes cluster
+- Ensure container CPU and memory resource limits do not exceed the specified limits in Kubernetes cluster
+
+## RECOMMENDATION
+
+Consider enabling the Azure Policy for Kubernetes integration on non-production AKS clusters.
+Additionally, assign one or more Azure policy definitions to enforce.
+
+## NOTES
+
+Azure Policy for Kubernetes is currently in preview.
+
+## LINKS
+
+- [Understand Azure Policy for Kubernetes clusters](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/policy-for-kubernetes)

--- a/docs/rules/en/Azure.AKS.ManagedIdentity.md
+++ b/docs/rules/en/Azure.AKS.ManagedIdentity.md
@@ -1,0 +1,46 @@
+---
+severity: Important
+category: Reliability
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.ManagedIdentity.md
+---
+
+# Use managed identities for AKS cluster authentication
+
+## SYNOPSIS
+
+Configure AKS clusters to use managed identities for managing cluster infrastructure.
+
+## DESCRIPTION
+
+During the lifecycle of an AKS cluster, the control plane configures a number of Azure resources.
+This includes node pools, networking, storage and other supporting services.
+
+When making calls against the Azure REST APIs, an identity must be used to authenticate requests.
+The type of identity the control plane will use is configurable at cluster creation.
+Either a service principal or system-assigned managed identity can be used.
+
+By default, the service principal credentials are valid for one year.
+Service principal credentials must be rotated before expiry to prevent issues.
+You can update or rotate the service principal credentials at any time.
+
+Using a system-assigned managed identity abstracts the process of managing a service principal.
+The managed identity is automatically created/ removed with the cluster.
+Managed identities also reduce maintenance (and improve security) by automatically rotating credentials.
+
+Separately, applications within an AKS cluster may use managed identities with AAD Pod Identity.
+
+## RECOMMENDATION
+
+Consider using managed identities during AKS cluster creation.
+Additionally, consider redeploying the AKS cluster with managed identities instead of service principals.
+
+## NOTES
+
+AKS clusters can not be updated to use managed identities for cluster infrastructure after deployment.
+
+## LINKS
+
+- [Use managed identities in Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
+- [What are managed identities for Azure resources?](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
+- [AAD Pod Identity](https://github.com/Azure/aad-pod-identity)

--- a/docs/rules/en/Azure.AKS.NodeMinPods.md
+++ b/docs/rules/en/Azure.AKS.NodeMinPods.md
@@ -1,6 +1,6 @@
 ---
 severity: Important
-category: Operations management
+category: Scalability
 resource: Azure Kubernetes Service
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.NodeMinPods.md
 ---

--- a/docs/rules/en/Azure.AKS.StandardLB.md
+++ b/docs/rules/en/Azure.AKS.StandardLB.md
@@ -1,0 +1,36 @@
+---
+severity: Important
+category: Scalability
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/docs/rules/en/Azure.AKS.StandardLB.md
+---
+
+# Use the Standard load balancer SKU
+
+## SYNOPSIS
+
+Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU.
+
+## DESCRIPTION
+
+When deploying an AKS cluster, either a Standard or Basic load balancer SKU can be configured.
+A Standard load balancer SKU is required for several AKS features including:
+
+- Multiple node pools
+- Availability zones
+- Authorized IP ranges
+
+These features improve the scalability and reliability of the cluster.
+
+## RECOMMENDATION
+
+Consider using Standard load balancer SKU during AKS cluster creation.
+Additionally, consider redeploying the AKS clusters with a Standard load balancer SKU configured.
+
+## NOTES
+
+AKS clusters can not be updated to use a Standard load balancer SKU after deployment.
+
+## LINKS
+
+- [Use a Standard SKU load balancer in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard)

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -45,7 +45,6 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
-[Azure.AKS.NodeMinPods](Azure.AKS.NodeMinPods.md) | Azure Kubernetes Cluster (AKS) nodes should use a minimum number of pods. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
@@ -79,6 +78,7 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
@@ -114,13 +114,16 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.NodeMinPods](Azure.AKS.NodeMinPods.md) | Azure Kubernetes Cluster (AKS) nodes should use a minimum number of pods. | Important
 [Azure.AKS.PoolScaleSet](Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
+[Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 
 ### Security configuration
 
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.AdminUser](Azure.ACR.AdminUser.md) | Use Azure AD accounts instead of using the registry admin user. | Critical
+[Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Cluster (AKS) clusters to use Azure Policy add-on for Kubernetes (Preview). | Important
 [Azure.AKS.NetworkPolicy](Azure.AKS.NetworkPolicy.md) | Deploy AKS clusters with Azure Network Policies enabled. | Important
 [Azure.AKS.PodSecurityPolicy](Azure.AKS.PodSecurityPolicy.md) | Configure AKS non-production clusters to use Pod Security Policies (Preview). | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -79,7 +79,9 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Cluster (AKS) clusters to use Azure Policy add-on for Kubernetes (Preview). | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness
 [Azure.AKS.NetworkPolicy](Azure.AKS.NetworkPolicy.md) | Deploy AKS clusters with Azure Network Policies enabled. | Important
@@ -87,6 +89,7 @@ Name | Synopsis | Severity
 [Azure.AKS.PodSecurityPolicy](Azure.AKS.PodSecurityPolicy.md) | Configure AKS non-production clusters to use Pod Security Policies (Preview). | Important
 [Azure.AKS.PoolScaleSet](Azure.AKS.PoolScaleSet.md) | Deploy AKS clusters with nodes pools based on VM scale sets. | Important
 [Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -10,12 +10,12 @@ if ($Null -ne $Configuration.minAKSVersion) {
 }
 
 # Synopsis: AKS clusters should have minimum number of nodes for failover and updates
-Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
     $TargetObject.Properties.agentPoolProfiles[0].count -ge 3
 }
 
 # Synopsis: AKS clusters should meet the minimum version
-Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; group = '2020_06' } {
     $minVersion = [Version]$Configuration.Azure_AKSMinimumVersion
     if ($PSRule.TargetType -eq 'Microsoft.ContainerService/managedClusters') {
         ([Version]$TargetObject.Properties.kubernetesVersion) -ge $minVersion
@@ -29,7 +29,7 @@ Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Mi
 } -Configure @{ Azure_AKSMinimumVersion = '1.16.9' }
 
 # Synopsis: AKS agent pools should run the same Kubernetes version as the cluster
-Rule 'Azure.AKS.PoolVersion' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.PoolVersion' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
     $clusterVersion = $TargetObject.Properties.kubernetesVersion
     foreach ($pool in $TargetObject.Properties.agentPoolProfiles) {
         $result = $Assert.HasDefaultValue($pool, 'orchestratorVersion', $clusterVersion);
@@ -44,17 +44,17 @@ Rule 'Azure.AKS.UseRBAC' -Type 'Microsoft.ContainerService/managedClusters' -Tag
 }
 
 # Synopsis: AKS clusters should use pod security policies
-Rule 'Azure.AKS.PodSecurityPolicy' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'preview' } {
+Rule 'Azure.AKS.PodSecurityPolicy' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'preview'; group = '2020_06' } {
     $Assert.HasFieldValue($TargetObject, 'Properties.enablePodSecurityPolicy', $True)
 }
 
 # Synopsis: AKS clusters should use network policies
-Rule 'Azure.AKS.NetworkPolicy' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.NetworkPolicy' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
     $Assert.HasFieldValue($TargetObject, 'Properties.networkProfile.networkPolicy', 'azure')
 }
 
 # Synopsis: AKS node pools should use scale sets
-Rule 'Azure.AKS.PoolScaleSet' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.PoolScaleSet' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; group = '2020_06' } {
     $result = $True
     if ($PSRule.TargetType -eq 'Microsoft.ContainerService/managedClusters') {
         $TargetObject.Properties.agentPoolProfiles | ForEach-Object {
@@ -74,7 +74,7 @@ Rule 'Azure.AKS.PoolScaleSet' -Type 'Microsoft.ContainerService/managedClusters'
 }
 
 # Synopsis: AKS nodes should use a minimum number of pods
-Rule 'Azure.AKS.NodeMinPods' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.NodeMinPods' -Type 'Microsoft.ContainerService/managedClusters', 'Microsoft.ContainerService/managedClusters/agentPools' -Tag @{ release = 'GA'; group = '2020_06' } {
     $agentPools = $Null;
     if ($PSRule.TargetType -eq 'Microsoft.ContainerService/managedClusters') {
         $agentPools = @($TargetObject.Properties.agentPoolProfiles);
@@ -91,7 +91,7 @@ Rule 'Azure.AKS.NodeMinPods' -Type 'Microsoft.ContainerService/managedClusters',
 } -Configure @{ Azure_AKSNodeMinimumMaxPods = 50 }
 
 # Synopsis: Use AKS naming requirements
-Rule 'Azure.AKS.Name' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.Name' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
     # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcontainerservice
 
     # Between 1 and 63 characters long
@@ -104,7 +104,7 @@ Rule 'Azure.AKS.Name' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{
 }
 
 # Synopsis: Use AKS naming requirements for DNS prefix
-Rule 'Azure.AKS.DNSPrefix' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {
+Rule 'Azure.AKS.DNSPrefix' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
     # Between 1 and 54 characters long
     $Assert.GreaterOrEqual($TargetObject, 'Properties.dnsPrefix', 1)
     $Assert.LessOrEqual($TargetObject, 'Properties.dnsPrefix', 54)
@@ -112,4 +112,19 @@ Rule 'Azure.AKS.DNSPrefix' -Type 'Microsoft.ContainerService/managedClusters' -T
     # Alphanumerics and hyphens
     # Start and end with alphanumeric
     Match 'Properties.dnsPrefix' '^[A-Za-z0-9]((-|[A-Za-z0-9]){0,}[A-Za-z0-9]){0,}$'
+}
+
+# Synopsis: Use a managed identity with AKS clusters
+Rule 'Azure.AKS.ManagedIdentity' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
+    $Assert.HasFieldValue($TargetObject, 'Identity.Type', 'SystemAssigned')
+}
+
+# Synopsis: Use a Standard load-balancer with AKS clusters
+Rule 'Azure.AKS.StandardLB' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; group = '2020_06' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.networkProfile.loadBalancerSku', 'standard')
+}
+
+# Synopsis: AKS clusters should use Azure Policy add-on
+Rule 'Azure.AKS.AzurePolicyAddOn' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'preview'; group = '2020_06' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.addonProfiles.azurePolicy.enabled', $True)
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -41,8 +41,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -63,8 +63,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -79,8 +79,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.UseRBAC' {
@@ -95,8 +95,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.PodSecurityPolicy' {
@@ -111,8 +111,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.NetworkPolicy' {
@@ -127,8 +127,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.PoolScaleSet' {
@@ -143,8 +143,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-C';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -159,8 +159,56 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
+        }
+
+        It 'Azure.AKS.ManagedIdentity' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.ManagedIdentity' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-C';
+            $ruleResult.TargetName | Should -Be 'cluster-D';
+        }
+
+        It 'Azure.AKS.StandardLB' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.StandardLB' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'cluster-D';
+        }
+
+        It 'Azure.AKS.AzurePolicyAddOn' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AzurePolicyAddOn' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
         }
     }
 
@@ -331,6 +379,48 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
             $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterA/agentpool3', 'clusterA/agentpool4';
+        }
+
+        It 'Azure.AKS.ManagedIdentity' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.ManagedIdentity' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+        }
+
+        It 'Azure.AKS.StandardLB' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.StandardLB' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+        }
+
+        It 'Azure.AKS.AzurePolicyAddOn' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AzurePolicyAddOn' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -26,6 +26,9 @@
             "apiVersion": "2019-10-01",
             "name": "[parameters('clusterName')]",
             "location": "[parameters('clusterLocation')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "properties": {
                 "kubernetesVersion": "1.16.9",
                 "dnsPrefix": "[concat('npcorp-', parameters('clusterName'))]",
@@ -51,7 +54,7 @@
                             "SubnetName": "subnet-aci"
                         }
                     },
-                    "azurepolicy": {
+                    "azurePolicy": {
                         "enabled": true
                     },
                     "httpApplicationRouting": {
@@ -72,7 +75,7 @@
                 "networkProfile": {
                     "networkPlugin": "azure",
                     "networkPolicy": "azure",
-                    "loadBalancerSku": "Basic",
+                    "loadBalancerSku": "Standard",
                     "serviceCidr": "192.168.0.0/16",
                     "dnsServiceIP": "192.168.0.4",
                     "dockerBridgeCidr": "172.17.0.1/16"

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -198,5 +198,151 @@
         "ResourceType": "Microsoft.ContainerService/managedClusters",
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-    }
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-D",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ContainerService/managedClusters/cluster-D",
+        "Identity": {
+          "PrincipalId": "00000000-0000-0000-0000-000000000000",
+          "TenantId": "00000000-0000-0000-0000-000000000000",
+          "Type": "SystemAssigned",
+          "UserAssignedIdentities": null
+        },
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "cluster-D",
+        "Name": "cluster-D",
+        "ExtensionResourceName": null,
+        "ParentResource": null,
+        "Plan": null,
+        "Properties": {
+          "provisioningState": "Succeeded",
+          "kubernetesVersion": "1.16.9",
+          "dnsPrefix": "cluster-D",
+          "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
+          "agentPoolProfiles": [
+            {
+              "name": "agentpool",
+              "count": 1,
+              "vmSize": "Standard_B2ms",
+              "osDiskSizeGB": 100,
+              "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+              "maxPods": 50,
+              "type": "VirtualMachineScaleSets",
+              "provisioningState": "Succeeded",
+              "orchestratorVersion": "1.16.9",
+              "nodeLabels": {},
+              "mode": "System",
+              "osType": "Linux",
+              "nodeImageVersion": "AKSUbuntu:1604:2020.05.13"
+            }
+          ],
+          "windowsProfile": {
+            "adminUsername": "azureuser"
+          },
+          "servicePrincipalProfile": {
+            "clientId": "msi"
+          },
+          "addonProfiles": {
+            "aciConnectorLinux": {
+              "enabled": true,
+              "config": {
+                "SubnetName": "subnet-B"
+              },
+              "identity": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aciconnectorlinux-cluster-D",
+                "clientId": "00000000-0000-0000-0000-000000000000",
+                "objectId": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "azurePolicy": {
+              "enabled": true,
+              "config": {
+                "version": "v2"
+              },
+              "identity": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurepolicy-cluster-D",
+                "clientId": "00000000-0000-0000-0000-000000000000",
+                "objectId": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "httpApplicationRouting": {
+              "enabled": true,
+              "config": {
+                "HTTPApplicationRoutingZoneName": "dca47a62fed041939528.region.aksapp.io"
+              },
+              "identity": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/httpapplicationrouting-cluster-D",
+                "clientId": "00000000-0000-0000-0000-000000000000",
+                "objectId": "00000000-0000-0000-0000-000000000000"
+              }
+            },
+            "kubeDashboard": {
+              "enabled": false,
+              "config": null
+            },
+            "omsagent": {
+              "enabled": true,
+              "config": {
+                "logAnalyticsWorkspaceResourceID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-region"
+              },
+              "identity": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagent-cluster-D",
+                "clientId": "00000000-0000-0000-0000-000000000000",
+                "objectId": "00000000-0000-0000-0000-000000000000"
+              }
+            }
+          },
+          "nodeResourceGroup": "MC_test-rg_cluster-D_region",
+          "enableRBAC": true,
+          "enablePodSecurityPolicy": true,
+          "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "loadBalancerProfile": {
+              "managedOutboundIPs": {
+                "count": 1
+              },
+              "effectiveOutboundIPs": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_test-rg_cluster-D_region/providers/Microsoft.Network/publicIPAddresses/00000000-0000-0000-0000-000000000000"
+                }
+              ]
+            },
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16",
+            "outboundType": "loadBalancer"
+          },
+          "aadProfile": {
+            "managed": true,
+            "adminGroupObjectIDs": null,
+            "tenantID": "00000000-0000-0000-0000-000000000000"
+          },
+          "maxAgentPools": 10,
+          "identityProfile": {
+            "kubeletidentity": {
+              "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_test-rg_cluster-D_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-D-agentpool",
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "objectId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "ExtensionResourceType": null,
+        "Sku": {
+          "Name": "Basic",
+          "Tier": "Free",
+          "Size": null,
+          "Family": null,
+          "Model": null,
+          "Capacity": null
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+      }
 ]


### PR DESCRIPTION
## PR Summary

- New rules:
  - Azure Kubernetes Service:
    - Check AKS clusters use a Standard load balancer SKU. #334
    - Check AKS clusters use Managed Identities for cluster infrastructure. #333
    - Check AKS clusters use Azure Policy add-on (preview). #405

Fixes #333 
Fixes #334 
Fixes #405 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
