### PR TITLE
Updated rule reasons and logic #424

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - New rules:
   - Subscriptions:
     - Check subscription is managed by PIM. [#422](https://github.com/Microsoft/PSRule.Rules.Azure/issues/422)
+- General improvements:
+  - Updated rule reasons and logic. [#424](https://github.com/Microsoft/PSRule.Rules.Azure/issues/424)
 
 ## v0.13.0
 

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -27,4 +27,6 @@
     RoleAssignmentCount = "The number of assignments is {0}."
     UnmanagedDisk = "The VM disk '{0}' is unmanaged."
     UnmanagedSubscription = "The subscription is not managed."
+    DBServerFirewallRuleCount = "The number of firewall rules ({0}) exceeded {1}."
+    DBServerFirewallPublicIPRange = "The number of public IP addresses permitted ({0}) exceeded {1}."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -11,7 +11,7 @@ if ($Null -ne $Configuration.minAKSVersion) {
 
 # Synopsis: AKS clusters should have minimum number of nodes for failover and updates
 Rule 'Azure.AKS.MinNodeCount' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $TargetObject.Properties.agentPoolProfiles[0].count -ge 3
+    $Assert.GreaterOrEqual($TargetObject, 'Properties.agentPoolProfiles[0].count', 3);
 }
 
 # Synopsis: AKS clusters should meet the minimum version

--- a/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AppService.Rule.ps1
@@ -7,7 +7,7 @@
 
 # Synopsis: Use an App Service Plan with at least two (2) instances
 Rule 'Azure.AppService.PlanInstanceCount' -Type 'Microsoft.Web/serverfarms' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $TargetObject.Sku.capacity -ge 2
+    $Assert.GreaterOrEqual($TargetObject, 'Sku.capacity', 2);
 }
 
 # Synopsis: Use at least a Standard App Service Plan

--- a/src/PSRule.Rules.Azure/rules/Azure.Automation.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Automation.Rule.ps1
@@ -7,25 +7,25 @@
 
 # Synopsis: Ensure variables are encrypted
 Rule 'Azure.Automation.EncryptVariables' -Type 'Microsoft.Automation/automationAccounts' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $variables = GetSubResources -ResourceType 'Microsoft.Automation/automationAccounts/variables'
+    $variables = GetSubResources -ResourceType 'Microsoft.Automation/automationAccounts/variables';
     if ($variables.Length -eq 0)
     {
         return $True;
     }
     foreach ($var in $variables) {
-        $var.properties.isEncrypted -eq $True
+        $Assert.HasFieldValue($var, 'properties.isEncrypted', $True);
     }
 }
 
 # Synopsis: Ensure webhook expiry is not longer than one year
 Rule 'Azure.Automation.WebHookExpiry' -Type 'Microsoft.Automation/automationAccounts' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $webhooks = GetSubResources -ResourceType 'Microsoft.Automation/automationAccounts/webhooks'
+    $webhooks = GetSubResources -ResourceType 'Microsoft.Automation/automationAccounts/webhooks';
     if ($webhooks.Length -eq 0)
     {
         return $True;
     }
     foreach ($webhook in $webhooks) {
         $days = [math]::Abs([int]((Get-Date) - $webhook.properties.expiryTime).Days)
-        $days -lt 365
+        $Assert.Less($days, '.', 365);
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -7,13 +7,15 @@
 
 # Synopsis: Use encrypted MySQL connections
 Rule 'Azure.MySQL.UseSSL' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled')
+    $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled');
 }
 
 # Synopsis: Determine if there is an excessive number of firewall rules
 Rule 'Azure.MySQL.FirewallRuleCount' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $firewallRules = GetSubResources -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules'
-    $firewallRules.Length -le 10;
+    $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules');
+    $Assert.
+        LessOrEqual($firewallRules, '.', 10).
+        WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
 }
 
 # Synopsis: Determine if access from Azure services is required
@@ -28,5 +30,7 @@ Rule 'Azure.MySQL.AllowAzureAccess' -Type 'Microsoft.DBforMySQL/servers' -Tag @{
 # Synopsis: Determine if there is an excessive number of permitted IP addresses
 Rule 'Azure.MySQL.FirewallIPRange' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $summary = GetIPAddressSummary
-    $summary.Public -le 10;
+    $Assert.
+        LessOrEqual($summary, 'Public', 10).
+        WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
@@ -7,13 +7,15 @@
 
 # Synopsis: Use encrypted PostgreSQL connections
 Rule 'Azure.PostgreSQL.UseSSL' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled')
+    $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled');
 }
 
 # Synopsis: Determine if there is an excessive number of firewall rules
 Rule 'Azure.PostgreSQL.FirewallRuleCount' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $firewallRules = GetSubResources -ResourceType 'Microsoft.DBforPostgreSQL/servers/firewallRules'
-    $firewallRules.Length -le 10;
+    $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforPostgreSQL/servers/firewallRules');
+    $Assert.
+        LessOrEqual($firewallRules, '.', 10).
+        WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
 }
 
 # Synopsis: Determine if access from Azure services is required
@@ -28,5 +30,7 @@ Rule 'Azure.PostgreSQL.AllowAzureAccess' -Type 'Microsoft.DBforPostgreSQL/server
 # Synopsis: Determine if there is an excessive number of permitted IP addresses
 Rule 'Azure.PostgreSQL.FirewallIPRange' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $summary = GetIPAddressSummary
-    $summary.Public -le 10;
+    $Assert.
+        LessOrEqual($summary, 'Public', 10).
+        WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Redis.Rule.ps1
@@ -7,10 +7,10 @@
 
 # Synopsis: Redis Cache should only accept secure connections
 Rule 'Azure.Redis.NonSslPort' -Type 'Microsoft.Cache/Redis' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $TargetObject.properties.enableNonSslPort -eq $False
+    $Assert.HasFieldValue($TargetObject, 'properties.enableNonSslPort', $False);
 }
 
 # Synopsis: Redis Cache should reject TLS versions older then 1.2
 Rule 'Azure.Redis.MinTLS' -Type 'Microsoft.Cache/Redis' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $TargetObject.properties.minimumTlsVersion -eq '1.2'
+    $Assert.HasFieldValue($TargetObject, 'properties.minimumTlsVersion', '1.2');
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
@@ -9,8 +9,10 @@
 
 # Synopsis: Determine if there is an excessive number of firewall rules
 Rule 'Azure.SQL.FirewallRuleCount' -Type 'Microsoft.Sql/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
-    $firewallRules = GetSubResources -ResourceType 'Microsoft.Sql/servers/firewallRules'
-    $firewallRules.Length -le 10;
+    $firewallRules = @(GetSubResources -ResourceType 'Microsoft.Sql/servers/firewallRules');
+    $Assert.
+        LessOrEqual($firewallRules, '.', 10).
+        WithReason(($LocalizedData.DBServerFirewallRuleCount -f $firewallRules.Length, 10), $True);
 }
 
 # Synopsis: Determine if access from Azure services is required
@@ -25,7 +27,9 @@ Rule 'Azure.SQL.AllowAzureAccess' -Type 'Microsoft.Sql/servers' -Tag @{ release 
 # Synopsis: Determine if there is an excessive number of permitted IP addresses
 Rule 'Azure.SQL.FirewallIPRange' -Type 'Microsoft.Sql/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $summary = GetIPAddressSummary
-    $summary.Public -le 10;
+    $Assert.
+        LessOrEqual($summary, 'Public', 10).
+        WithReason(($LocalizedData.DBServerFirewallPublicIPRange -f $summary.Public, 10), $True);
 }
 
 # Synopsis: Enable Advanced Thread Protection for Azure SQL logical server

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -59,6 +59,7 @@ Describe 'Azure.MySQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of firewall rules (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -91,6 +92,7 @@ Describe 'Azure.MySQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of public IP addresses permitted (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
@@ -59,6 +59,7 @@ Describe 'Azure.PostgreSQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of firewall rules (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -91,6 +92,7 @@ Describe 'Azure.PostgreSQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of public IP addresses permitted (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
@@ -43,6 +43,7 @@ Describe 'Azure.SQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of firewall rules (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -75,6 +76,7 @@ Describe 'Azure.SQL' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-B';
+            $ruleResult.Reason | Should -BeLike "The number of public IP addresses permitted (*) exceeded 10.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });


### PR DESCRIPTION
## PR Summary

Updated rule reasons and logic for:


- Azure.AKS.MinNodeCount
- Azure.AppService.PlanInstanceCount
- Azure.Automation.EncryptVariables
- Azure.Automation.WebHookExpiry
- Azure.MySQL.UseSSL
- Azure.MySQL.FirewallRuleCount
- Azure.MySQL.FirewallIPRange
- Azure.PostgreSQL.UseSSL
- Azure.PostgreSQL.FirewallRuleCount
- Azure.PostgreSQL.FirewallIPRange
- Azure.Redis.NonSslPort
- Azure.Redis.MinTLS
- Azure.SQL.FirewallRuleCount
- Azure.SQL.FirewallIPRange
- Azure.VNET.SingleDNS
- Azure.VNET.PeerState
- Azure.AppGw.MinInstance
- Azure.AppGw.Prevention
- Azure.AppGw.WAFEnabled
- Azure.AppGw.OWASP

Fixes #424 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
