### PR TITLE
Fix resource tags rule to exclude diagnostic settings #448

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed resource tags rule to exclude diagnostic settings. [#448](https://github.com/Microsoft/PSRule.Rules.Azure/issues/448)
+
 ## v0.14.0
 
 What's changed since v0.13.0:

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -248,16 +248,23 @@ function global:SupportsTags {
     param ()
     process {
         if (
+            ($PSRule.TargetType -eq 'Microsoft.Subscription') -or
             ($PSRule.TargetType -notlike 'Microsoft.*/*') -or
+            ($PSRule.TargetType -like 'Microsoft.Addons/*') -or
+            ($PSRule.TargetType -like 'Microsoft.Advisor/*') -or
             ($PSRule.TargetType -like 'Microsoft.Authorization/*') -or
             ($PSRule.TargetType -like 'Microsoft.Billing/*') -or
+            ($PSRule.TargetType -like 'Microsoft.Blueprint/*') -or
+            ($PSRule.TargetType -like 'Microsoft.Capacity/*') -or
             ($PSRule.TargetType -like 'Microsoft.Classic*') -or
             ($PSRule.TargetType -like 'Microsoft.Consumption/*') -or
             ($PSRule.TargetType -like 'Microsoft.Gallery/*') -or
             ($PSRule.TargetType -like 'Microsoft.Security/*') -or
             ($PSRule.TargetType -like 'microsoft.support/*') -or
+            ($PSRule.TargetType -like 'microsoft.insights/diagnosticSettings') -or
             ($PSRule.TargetType -like 'Microsoft.WorkloadMonitor/*') -or
             ($PSRule.TargetType -like '*/providers/roleAssignments') -or
+            ($PSRule.TargetType -like '*/providers/diagnosticSettings') -or
 
             # Exclude sub-resources by default
             ($PSRule.TargetType -like 'Microsoft.*/*/*' -and !(
@@ -275,6 +282,11 @@ function global:SupportsTags {
                 $PSRule.TargetType -eq 'Microsoft.Resources/deployments' -or
                 $PSRule.TargetType -eq 'Microsoft.Resources/deploymentScripts' -or
                 $PSRule.TargetType -eq 'Microsoft.Resources/resourceGroups'
+            )) -or
+
+            # Some exceptions to resources (https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-support#microsoftcostmanagement)
+            ($PSRule.TargetType -like 'Microsoft.CostManagement/*' -and !(
+                $PSRule.TargetType -eq 'Microsoft.CostManagement/Connectors'
             ))
         ) {
             return $False;

--- a/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Resource.Rule.ps1
@@ -10,7 +10,7 @@ if ($Null -ne $Configuration.azureAllowedRegions) {
 }
 
 # Synopsis: Resources should be tagged
-Rule 'Azure.Resource.UseTags' -If { SupportsTags } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
+Rule 'Azure.Resource.UseTags' -If { (SupportsTags) -and $PSRule.TargetType -ne 'Microsoft.Subscription' } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     Reason $LocalizedData.ResourceNotTagged
     # List of resource that support tags can be found here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/tag-support
     (Exists 'Tags') -and

--- a/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for Azure resource tags
+#
+
+[CmdletBinding()]
+param (
+
+)
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+if ($Env:SYSTEM_DEBUG -eq 'true') {
+    $VerbosePreference = 'Continue';
+}
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+Describe 'SupportsTags' -Tag 'Common', 'Filters', 'SupportsTags' {
+    $invokeParams = @{
+        Baseline = 'Azure.All'
+        Module = 'PSRule.Rules.Azure'
+        WarningAction = 'Ignore'
+        ErrorAction = 'Stop'
+    }
+    $tempResource = [PSCustomObject]@{
+        Type = 'None'
+    }
+
+    Context 'Supports tags' {
+        # Supported types
+        $resourceTypes = @(
+            'Microsoft.ContainerRegistry/registries'
+            'Microsoft.Network/networkSecurityGroups'
+            'Microsoft.Network/routeTables'
+            'Microsoft.Resources/resourceGroups'
+            'Microsoft.CostManagement/Connectors'
+        )
+        foreach ($resourceType in $resourceTypes) {
+            It $resourceType {
+                $tempResource.Type = $resourceType;
+                $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
+                $result.Outcome | Should -Be 'Fail';
+            }
+        }
+    }
+
+    Context 'Does not support tags' {
+        $resourceTypes = @(
+            'Microsoft.Authorization/policyDefinitions'
+            'Microsoft.Authorization/policySetDefinitions'
+            'Microsoft.Authorization/policyAssignments'
+            'microsoft.insights/diagnosticSettings'
+            'Microsoft.KeyVault/vaults/providers/diagnosticSettings'
+            'Microsoft.CostManagement/budgets'
+        )
+        foreach ($resourceType in $resourceTypes) {
+            It $resourceType {
+                $tempResource.Type = $resourceType;
+                $result = $tempResource | Invoke-PSRule @invokeParams -Name 'Azure.Resource.UseTags' -Outcome All;
+                $result.Outcome | Should -Be 'None';
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Fixed resource tags rule to exclude diagnostic settings. #448

Fixes #448 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
