### PR TITLE
Storage Account public access and TLS #455 #456

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- New rules:
+  - Storage Account:
+    - Check Storage Accounts reject TLS versions older than 1.2. [#455](https://github.com/Microsoft/PSRule.Rules.Azure/issues/455)
+    - Check Storage Accounts only accept authorized requests. [#456](https://github.com/Microsoft/PSRule.Rules.Azure/issues/456)
+
 ## v0.14.1
 
 What's changed since v0.14.1:
@@ -172,7 +177,7 @@ What's changed since v0.11.0:
   - SQL Database:
     - Check SQL Database uses TDE. [#379](https://github.com/Microsoft/PSRule.Rules.Azure/issues/379)
     - Check SQL Database uses AAD authentication. [#378](https://github.com/Microsoft/PSRule.Rules.Azure/issues/378)
-  - Storage:
+  - Storage Account:
     - Check Storage Account name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
     - Check Storage blob containers use private access type. [#365](https://github.com/Microsoft/PSRule.Rules.Azure/issues/365)
   - Virtual Network:
@@ -220,7 +225,7 @@ What's changed since pre-release v0.12.0-B2005026:
     - Check Route table name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - SignalR Service:
     - Check SignalR Service name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
-  - Storage:
+  - Storage Account:
     - Check Storage Account name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
   - Virtual Network:
     - Check VNET name requirements. [#373](https://github.com/Microsoft/PSRule.Rules.Azure/issues/373)
@@ -235,7 +240,7 @@ What's changed since pre-release v0.12.0-B2005026:
 ## v0.12.0-B2005005 (pre-release)
 
 - New rules:
-  - Storage:
+  - Storage Account:
     - Check Storage blob containers use private access type. [#365](https://github.com/Microsoft/PSRule.Rules.Azure/issues/365)
   - Policy:
     - Check Policy definitions use descriptive fields. [#364](https://github.com/Microsoft/PSRule.Rules.Azure/issues/364)

--- a/docs/baselines/en/Azure.All.md
+++ b/docs/baselines/en/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 142 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 148 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -24,13 +24,17 @@ Name | Synopsis | Severity
 [Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
+[Azure.APIM.APIDescriptors](Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.APIM.EncryptValues](Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important
 [Azure.APIM.ManagedIdentity](Azure.APIM.ManagedIdentity.md) | Use managed identities to access Azure resources. | Important
+[Azure.APIM.Name](Azure.APIM.Name.md) | API Management service names should meet naming requirements. | Awareness
 [Azure.APIM.ProductApproval](Azure.APIM.ProductApproval.md) | Configure products to require approval. | Important
+[Azure.APIM.ProductDescriptors](Azure.APIM.ProductDescriptors.md) | API Management products should have a display name and description. | Awareness
 [Azure.APIM.ProductSubscription](Azure.APIM.ProductSubscription.md) | Configure products to require a subscription. | Important
+[Azure.APIM.ProductTerms](Azure.APIM.ProductTerms.md) | Set legal terms for each product registered in API Management. | Important
 [Azure.APIM.Protocols](Azure.APIM.Protocols.md) | API Management should only accept a minimum of TLS 1.2. | Important
 [Azure.APIM.SampleProducts](Azure.APIM.SampleProducts.md) | Remove starter and unlimited sample products. | Awareness
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
@@ -105,6 +109,8 @@ Name | Synopsis | Severity
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
+[Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
+[Azure.Storage.MinTLS](Azure.Storage.MinTLS.md) | Storage Accounts should reject TLS versions older than 1.2. | Important
 [Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important

--- a/docs/baselines/en/Azure.Default.md
+++ b/docs/baselines/en/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 140 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 146 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -22,13 +22,17 @@ Name | Synopsis | Severity
 [Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
+[Azure.APIM.APIDescriptors](Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.APIM.EncryptValues](Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important
 [Azure.APIM.ManagedIdentity](Azure.APIM.ManagedIdentity.md) | Use managed identities to access Azure resources. | Important
+[Azure.APIM.Name](Azure.APIM.Name.md) | API Management service names should meet naming requirements. | Awareness
 [Azure.APIM.ProductApproval](Azure.APIM.ProductApproval.md) | Configure products to require approval. | Important
+[Azure.APIM.ProductDescriptors](Azure.APIM.ProductDescriptors.md) | API Management products should have a display name and description. | Awareness
 [Azure.APIM.ProductSubscription](Azure.APIM.ProductSubscription.md) | Configure products to require a subscription. | Important
+[Azure.APIM.ProductTerms](Azure.APIM.ProductTerms.md) | Set legal terms for each product registered in API Management. | Important
 [Azure.APIM.Protocols](Azure.APIM.Protocols.md) | API Management should only accept a minimum of TLS 1.2. | Important
 [Azure.APIM.SampleProducts](Azure.APIM.SampleProducts.md) | Remove starter and unlimited sample products. | Awareness
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
@@ -103,6 +107,8 @@ Name | Synopsis | Severity
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
+[Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
+[Azure.Storage.MinTLS](Azure.Storage.MinTLS.md) | Storage Accounts should reject TLS versions older than 1.2. | Important
 [Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important

--- a/docs/baselines/en/Azure.Preview.md
+++ b/docs/baselines/en/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 142 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 148 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -24,13 +24,17 @@ Name | Synopsis | Severity
 [Azure.AKS.StandardLB](Azure.AKS.StandardLB.md) | Azure Kubernetes Clusters (AKS) should use a Standard load balancer SKU. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
+[Azure.APIM.APIDescriptors](Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.APIM.EncryptValues](Azure.APIM.EncryptValues.md) | API Management named values should be encrypted. | Important
 [Azure.APIM.HTTPBackend](Azure.APIM.HTTPBackend.md) | Use HTTPS for communication to backend services. | Critical
 [Azure.APIM.HTTPEndpoint](Azure.APIM.HTTPEndpoint.md) | Enforce HTTPS for communication to API clients. | Important
 [Azure.APIM.ManagedIdentity](Azure.APIM.ManagedIdentity.md) | Use managed identities to access Azure resources. | Important
+[Azure.APIM.Name](Azure.APIM.Name.md) | API Management service names should meet naming requirements. | Awareness
 [Azure.APIM.ProductApproval](Azure.APIM.ProductApproval.md) | Configure products to require approval. | Important
+[Azure.APIM.ProductDescriptors](Azure.APIM.ProductDescriptors.md) | API Management products should have a display name and description. | Awareness
 [Azure.APIM.ProductSubscription](Azure.APIM.ProductSubscription.md) | Configure products to require a subscription. | Important
+[Azure.APIM.ProductTerms](Azure.APIM.ProductTerms.md) | Set legal terms for each product registered in API Management. | Important
 [Azure.APIM.Protocols](Azure.APIM.Protocols.md) | API Management should only accept a minimum of TLS 1.2. | Important
 [Azure.APIM.SampleProducts](Azure.APIM.SampleProducts.md) | Remove starter and unlimited sample products. | Awareness
 [Azure.AppGw.MinInstance](Azure.AppGw.MinInstance.md) | Application Gateways should use a minimum of two instances. | Important
@@ -105,6 +109,8 @@ Name | Synopsis | Severity
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
+[Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
+[Azure.Storage.MinTLS](Azure.Storage.MinTLS.md) | Storage Accounts should reject TLS versions older than 1.2. | Important
 [Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important

--- a/docs/rules/en/Azure.Storage.BlobAccessType.md
+++ b/docs/rules/en/Azure.Storage.BlobAccessType.md
@@ -1,11 +1,11 @@
 ---
 severity: Important
 category: Security configuration
-resource: Storage
+resource: Storage Account
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.Storage.BlobAccessType.md
 ---
 
-# Use private blob container
+# Use private blob containers
 
 ## SYNOPSIS
 
@@ -14,16 +14,16 @@ Storage Accounts use containers configured with an access type other than Privat
 ## DESCRIPTION
 
 Azure Storage Account blob containers use the Private access type by default.
-Additional access types Blob and Container provide anonymous access to blobs without authentication.
+Additional access types Blob and Container provide anonymous access to blobs without authorized.
 Blob and Container access types are not intended for access to customer data.
 
 Blob and Container access types are designed for public access scenarios.
-For example, Content Delivery Network (CDN) and storage of web assets like .css and .js files in public websites.
+For example, storage of web assets like .css and .js files used in public websites.
 
 ## RECOMMENDATION
 
 To provide secure access to data always use the Private access type (default).
-Then use Shared Access Signatures (SAS) to provide secure access to individual blobs or containers as required.
+Use Shared Access Signatures (SAS) to provide secure access to individual blobs or containers as required.
 
 Consider using SAS tokens stored securely in a key vault, rotated and only accessed by approved applications.
 

--- a/docs/rules/en/Azure.Storage.BlobPublicAccess.md
+++ b/docs/rules/en/Azure.Storage.BlobPublicAccess.md
@@ -1,0 +1,34 @@
+---
+severity: Important
+category: Security configuration
+resource: Storage Account
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.Storage.BlobPublicAccess.md
+---
+
+# Disallow anonymous access to blob service
+
+## SYNOPSIS
+
+Storage Accounts should only accept authorized requests.
+
+## DESCRIPTION
+
+Blob containers in Azure Storage Accounts can be configured for private or anonymous public access.
+By default, containers are private and only accessible with a credential or access token.
+When a container is configured with an access type other than private, anonymous access is permitted.
+
+Anonymous access to blobs or containers can be restricted by setting `AllowBlobPublicAccess` to `false`.
+This enhanced security setting for a storage account overrides the individual settings for blob containers.
+When you disallow public access for a storage account, blobs are no longer accessible anonymously.
+
+## RECOMMENDATION
+
+Consider disallowing anonymous access to storage account blobs unless specifically required.
+Also consider enforcing this setting using Azure Policy.
+
+## LINKS
+
+- [Allow or disallow public read access for a storage account](https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure#allow-or-disallow-public-read-access-for-a-storage-account)
+- [Remediate anonymous public access](https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent#remediate-anonymous-public-access)
+- [Use Azure Policy to enforce authorized access](https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent#use-azure-policy-to-enforce-authorized-access)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts#StorageAccountPropertiesCreateParameters)

--- a/docs/rules/en/Azure.Storage.MinTLS.md
+++ b/docs/rules/en/Azure.Storage.MinTLS.md
@@ -1,0 +1,32 @@
+---
+severity: Important
+category: Security configuration
+resource: Storage Account
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.Storage.MinTLS.md
+---
+
+# Storage Account minimum TLS version
+
+## SYNOPSIS
+
+Storage Accounts should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that Azure Storage Accounts accept for blob storage is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Storage Accounts lets you disable outdated protocols and enforce TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+## RECOMMENDATION
+
+Consider configuring the minimum supported TLS version to be 1.2.
+Also consider enforcing this setting using Azure Policy.
+
+## LINKS
+
+- [Enforce a minimum required version of Transport Layer Security (TLS) for requests to a storage account](https://docs.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version)
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [Use Azure Policy to enforce the minimum TLS version](https://docs.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version#use-azure-policy-to-enforce-the-minimum-tls-version)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts#StorageAccountPropertiesCreateParameters)

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -192,6 +192,8 @@ Name | Synopsis | Severity
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
+[Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
+[Azure.Storage.MinTLS](Azure.Storage.MinTLS.md) | Storage Accounts should reject TLS versions older than 1.2. | Important
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
 [Azure.TrafficManager.Protocol](Azure.TrafficManager.Protocol.md) | Monitor Traffic Manager web-based endpoints with HTTPS. | Important

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -225,16 +225,13 @@ Name | Synopsis | Severity
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 
-### Storage
-
-Name | Synopsis | Severity
----- | -------- | --------
-[Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
-
 ### Storage Account
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important
+[Azure.Storage.BlobPublicAccess](Azure.Storage.BlobPublicAccess.md) | Storage Accounts should only accept authorized requests. | Important
+[Azure.Storage.MinTLS](Azure.Storage.MinTLS.md) | Storage Accounts should reject TLS versions older than 1.2. | Important
 [Azure.Storage.Name](Azure.Storage.Name.md) | Storage Account names should meet naming requirements. | Awareness
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important

--- a/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
@@ -27,6 +27,12 @@ Rule 'Azure.Storage.SoftDelete' -Type 'Microsoft.Storage/storageAccounts' -If { 
     $Assert.HasFieldValue($serviceProperties, 'properties.deleteRetentionPolicy.enabled', $True);
 }
 
+# Synopsis: Disallow blob containers with public access types.
+Rule 'Azure.Storage.BlobPublicAccess' -Type 'Microsoft.Storage/storageAccounts' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $Assert.
+        HasFieldValue($TargetObject, 'Properties.allowBlobPublicAccess', $False);
+}
+
 # Synopsis: Avoid using Blob or Container access type
 Rule 'Azure.Storage.BlobAccessType' -Type 'Microsoft.Storage/storageAccounts', 'Microsoft.Storage/storageAccounts/blobServices/containers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $containers = @($TargetObject);
@@ -41,6 +47,13 @@ Rule 'Azure.Storage.BlobAccessType' -Type 'Microsoft.Storage/storageAccounts', '
             HasFieldValue($container, 'Properties.publicAccess', 'None').
             WithReason(($LocalizedData.PublicAccessStorageContainer -f $container.name, $container.Properties.publicAccess), $True);
     }
+}
+
+# Synopsis: Use at least TLS 1.2.
+Rule 'Azure.Storage.MinTLS' -Type 'Microsoft.Storage/storageAccounts' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $Assert.
+        HasFieldValue($TargetObject, 'Properties.minimumTlsVersion', 'TLS1_2').
+        Reason($LocalizedData.MinTLSVersion, $TargetObject.Properties.minimumTlsVersion);
 }
 
 # Synopsis: Use Storage naming requirements

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -109,6 +109,22 @@ Describe 'Azure.Storage' -Tag Storage {
             $ruleResult.TargetName | Should -Be 'storage-D';
         }
 
+        It 'Azure.Storage.BlobPublicAccess' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Storage.BlobPublicAccess' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C', 'storage-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'storage-A';
+        }
+
         It 'Azure.Storage.BlobAccessType' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Storage.BlobAccessType' };
 
@@ -122,7 +138,23 @@ Describe 'Azure.Storage' -Tag Storage {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'storage-A', 'storage-C', 'storage-D';
+            $ruleResult.TargetName | Should -BeIn 'storage-A', 'storage-C', 'storage-D';
+        }
+
+        It 'Azure.Storage.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Storage.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C', 'storage-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'storage-A';
         }
     }
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
@@ -14,6 +14,8 @@
                 "defaultAction": "Allow"
             },
             "supportsHttpsTrafficOnly": true,
+            "allowBlobPublicAccess": false,
+            "minimumTlsVersion": "TLS1_2",
             "encryption": {
                 "services": {
                     "file": {
@@ -120,6 +122,8 @@
                 "defaultAction": "Allow"
             },
             "supportsHttpsTrafficOnly": false,
+            "allowBlobPublicAccess": true,
+            "minimumTlsVersion": "TLS1_0",
             "encryption": {
                 "services": {
                     "file": {
@@ -138,7 +142,7 @@
                 "file": "https://storage-B.file.core.windows.net/"
             },
             "primaryLocation": "region",
-            "statusOfPrimary": "available"
+            "statusOfPrimary": "available",
         },
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Storage/storageAccounts",


### PR DESCRIPTION
## PR Summary

- Check Storage Accounts reject TLS versions older than 1.2. #455 
- Check Storage Accounts only accept authorized requests. #456

Fixes #455 
Fixes #456 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
