### PR TITLE
Export fixes for #464 #465 #466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed export of non-blob Storage Accounts. [#464](https://github.com/Microsoft/PSRule.Rules.Azure/issues/464)
+  - Fixed export of subscription Security Center data based on API version. [#465](https://github.com/Microsoft/PSRule.Rules.Azure/issues/465)
+  - Fixed masking of sharedKey when property does not exist. [#466](https://github.com/Microsoft/PSRule.Rules.Azure/issues/466)
+
 ## v0.15.0-B2008026 (pre-release)
 
 - New rules:

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -681,7 +681,7 @@ function VisitStorageAccount {
     process {
         $resources = @();
         if ($Resource.Kind -ne 'FileStorage') {
-            $blobServices += GetSubResource @PSBoundParameters -ResourceType 'Microsoft.Storage/storageAccounts/blobServices' -ApiVersion '2019-04-01';
+            $blobServices = @(GetSubResource @PSBoundParameters -ResourceType 'Microsoft.Storage/storageAccounts/blobServices' -ApiVersion '2019-04-01');
             foreach ($blobService in $blobServices) {
                 $resources += $blobService;
                 $resources += Get-AzResource -Name "$($Resource.Name)/$($blobService.Name)" -ResourceType 'Microsoft.Storage/storageAccounts/blobServices/containers' -ResourceGroupName $Resource.ResourceGroupName -DefaultProfile $Context -ApiVersion '2019-04-01' -ExpandProperties;


### PR DESCRIPTION
## PR Summary

- Fixed export of non-blob Storage Accounts. #464
- Fixed export of subscription Security Center data based on API version. #465
- Fixed masking of sharedKey when property does not exist. #466

Fixes #464 
Fixes #465 
Fixes #466 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
