### PR TITLE
Database TLS checks #469 #470 #471

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- New rules:
+  - Database for MySQL:
+    - Check database servers reject TLS versions older than 1.2. [#469](https://github.com/Microsoft/PSRule.Rules.Azure/issues/469)
+  - Database for PostgreSQL:
+    - Check database servers reject TLS versions older than 1.2. [#470](https://github.com/Microsoft/PSRule.Rules.Azure/issues/470)
+  - SQL Database:
+    - Check database servers reject TLS versions older than 1.2. [#471](https://github.com/Microsoft/PSRule.Rules.Azure/issues/471)
+
 ## v0.15.0-B2008034 (pre-release)
 
 What's changed since pre-release v0.15.0-B2008026:

--- a/docs/baselines/en/Azure.All.md
+++ b/docs/baselines/en/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 152 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 155 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -72,6 +72,7 @@ Name | Synopsis | Severity
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical
 [Azure.NSG.AnyInboundSource](Azure.NSG.AnyInboundSource.md) | Network security groups (NSGs) should avoid rules that allow any inbound source. | Critical
 [Azure.NSG.Associated](Azure.NSG.Associated.md) | Network Security Groups (NSGs) should be associated. | Awareness
@@ -82,6 +83,7 @@ Name | Synopsis | Severity
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.PostgreSQL.MinTLS](Azure.PostgreSQL.MinTLS.md) | PostgreSQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections. | Critical
 [Azure.PublicIP.DNSLabel](Azure.PublicIP.DNSLabel.md) | Public IP domain name labels should meet naming requirements. | Awareness
 [Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP address should be attached. | Awareness
@@ -106,6 +108,7 @@ Name | Synopsis | Severity
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.SQL.MinTLS](Azure.SQL.MinTLS.md) | Azure SQL Database servers should reject TLS versions older than 1.2. | Critical
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important

--- a/docs/baselines/en/Azure.Default.md
+++ b/docs/baselines/en/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 150 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 153 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -70,6 +70,7 @@ Name | Synopsis | Severity
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical
 [Azure.NSG.AnyInboundSource](Azure.NSG.AnyInboundSource.md) | Network security groups (NSGs) should avoid rules that allow any inbound source. | Critical
 [Azure.NSG.Associated](Azure.NSG.Associated.md) | Network Security Groups (NSGs) should be associated. | Awareness
@@ -80,6 +81,7 @@ Name | Synopsis | Severity
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.PostgreSQL.MinTLS](Azure.PostgreSQL.MinTLS.md) | PostgreSQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections. | Critical
 [Azure.PublicIP.DNSLabel](Azure.PublicIP.DNSLabel.md) | Public IP domain name labels should meet naming requirements. | Awareness
 [Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP address should be attached. | Awareness
@@ -104,6 +106,7 @@ Name | Synopsis | Severity
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.SQL.MinTLS](Azure.SQL.MinTLS.md) | Azure SQL Database servers should reject TLS versions older than 1.2. | Critical
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important

--- a/docs/baselines/en/Azure.Preview.md
+++ b/docs/baselines/en/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 152 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 155 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -72,6 +72,7 @@ Name | Synopsis | Severity
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical
 [Azure.NSG.AnyInboundSource](Azure.NSG.AnyInboundSource.md) | Network security groups (NSGs) should avoid rules that allow any inbound source. | Critical
 [Azure.NSG.Associated](Azure.NSG.Associated.md) | Network Security Groups (NSGs) should be associated. | Awareness
@@ -82,6 +83,7 @@ Name | Synopsis | Severity
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.PostgreSQL.MinTLS](Azure.PostgreSQL.MinTLS.md) | PostgreSQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections. | Critical
 [Azure.PublicIP.DNSLabel](Azure.PublicIP.DNSLabel.md) | Public IP domain name labels should meet naming requirements. | Awareness
 [Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP address should be attached. | Awareness
@@ -106,6 +108,7 @@ Name | Synopsis | Severity
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.SQL.MinTLS](Azure.SQL.MinTLS.md) | Azure SQL Database servers should reject TLS versions older than 1.2. | Critical
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important

--- a/docs/rules/en/Azure.MySQL.MinTLS.md
+++ b/docs/rules/en/Azure.MySQL.MinTLS.md
@@ -1,0 +1,31 @@
+---
+severity: Critical
+category: Security configuration
+resource: Azure Database for MySQL
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.MySQL.MinTLS.md
+---
+
+# MySQL DB server minimum TLS version
+
+## SYNOPSIS
+
+MySQL DB servers should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that MySQL DB servers accept is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+## RECOMMENDATION
+
+Consider configuring the minimum supported TLS version to be 1.2.
+
+## LINKS
+
+- [TLS enforcement in Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/concepts-ssl-connection-security#tls-enforcement-in-azure-database-for-mysql)
+- [Set TLS configurations for Azure Database for MySQL](https://docs.microsoft.com/en-us/azure/mysql/howto-tls-configurations#set-tls-configurations-for-azure-database-for-mysql)
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.dbformysql/servers#ServerPropertiesForCreate)

--- a/docs/rules/en/Azure.PostgreSQL.MinTLS.md
+++ b/docs/rules/en/Azure.PostgreSQL.MinTLS.md
@@ -1,0 +1,31 @@
+---
+severity: Critical
+category: Security configuration
+resource: Azure Database for PostgreSQL
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.PostgreSQL.MinTLS.md
+---
+
+# PostgreSQL DB server minimum TLS version
+
+## SYNOPSIS
+
+PostgreSQL DB servers should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that PostgreSQL DB servers accept is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+## RECOMMENDATION
+
+Consider configuring the minimum supported TLS version to be 1.2.
+
+## LINKS
+
+- [TLS enforcement in Azure Database for PostgreSQL Single server](https://docs.microsoft.com/en-us/azure/postgresql/concepts-ssl-connection-security#tls-enforcement-in-azure-database-for-postgresql-single-server)
+- [Set TLS configurations for Azure Database for PostgreSQL - Single server](https://docs.microsoft.com/en-us/azure/postgresql/howto-tls-configurations#set-tls-configurations-for-azure-database-for-postgresql---single-server)
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/servers#ServerPropertiesForCreate)

--- a/docs/rules/en/Azure.Redis.MinTLS.md
+++ b/docs/rules/en/Azure.Redis.MinTLS.md
@@ -6,7 +6,7 @@ online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/r
 ms-content-id: 31240bca-b04f-4267-9c31-cfca4e91cfbf
 ---
 
-# Azure.Redis.MinTLS
+# Redis Cache minimum TLS version
 
 ## SYNOPSIS
 
@@ -14,8 +14,20 @@ Redis Cache should reject TLS versions older then 1.2.
 
 ## DESCRIPTION
 
-Redis Cache should reject TLS versions older then 1.2.
+The minimum version of TLS that Redis Cache accepts is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
 
 ## RECOMMENDATION
 
-Redis Cache should reject TLS versions older then 1.2.
+Consider configuring the minimum supported TLS version to be 1.2.
+Support for TLS 1.0/ 1.1 version will be removed.
+
+## LINKS
+
+- [Remove TLS 1.0 and 1.1 from use with Azure Cache for Redis](https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11)
+- [Configure Azure Cache for Redis settings](https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-configure#access-ports)
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.cache/redis#RedisCreateProperties)

--- a/docs/rules/en/Azure.SQL.MinTLS.md
+++ b/docs/rules/en/Azure.SQL.MinTLS.md
@@ -1,0 +1,30 @@
+---
+severity: Critical
+category: Security configuration
+resource: SQL Database
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.SQL.MinTLS.md
+---
+
+# Azure SQL DB server minimum TLS version
+
+## SYNOPSIS
+
+Azure SQL Database servers should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that Azure SQL Database servers accept is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+## RECOMMENDATION
+
+Consider configuring the minimum supported TLS version to be 1.2.
+
+## LINKS
+
+- [Minimal TLS Version](https://docs.microsoft.com/en-gb/azure/azure-sql/database/connectivity-settings#minimal-tls-version)
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [Azure template reference](https://docs.microsoft.com/en-gb/azure/templates/microsoft.sql/servers#ServerProperties)

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -181,11 +181,13 @@ Name | Synopsis | Severity
 [Azure.FrontDoor.WAF.Mode](Azure.FrontDoor.WAF.Mode.md) | Use protection mode in Front Door Web Application Firewall (WAF) policies to protect back end resources. | Critical
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
+[Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical
 [Azure.NSG.AnyInboundSource](Azure.NSG.AnyInboundSource.md) | Network security groups (NSGs) should avoid rules that allow any inbound source. | Critical
 [Azure.NSG.LateralTraversal](Azure.NSG.LateralTraversal.md) | Deny outbound management connections from non-management hosts. | Important
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
+[Azure.PostgreSQL.MinTLS](Azure.PostgreSQL.MinTLS.md) | PostgreSQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections. | Critical
 [Azure.Redis.MinTLS](Azure.Redis.MinTLS.md) | Redis Cache should reject TLS versions older then 1.2. | Critical
 [Azure.Redis.NonSslPort](Azure.Redis.NonSslPort.md) | Redis Cache should only accept secure connections. | Critical
@@ -193,6 +195,7 @@ Name | Synopsis | Severity
 [Azure.SQL.AllowAzureAccess](Azure.SQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
+[Azure.SQL.MinTLS](Azure.SQL.MinTLS.md) | Azure SQL Database servers should reject TLS versions older than 1.2. | Critical
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 [Azure.Storage.BlobAccessType](Azure.Storage.BlobAccessType.md) | Storage Accounts use containers configured with an access type other than Private. | Important

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -72,6 +72,7 @@ Name | Synopsis | Severity
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical
 
 ### Azure Database for PostgreSQL
@@ -81,6 +82,7 @@ Name | Synopsis | Severity
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required. | Important
 [Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.PostgreSQL.MinTLS](Azure.PostgreSQL.MinTLS.md) | PostgreSQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections. | Critical
 
 ### Azure Kubernetes Service
@@ -226,6 +228,7 @@ Name | Synopsis | Severity
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server. | Important
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
+[Azure.SQL.MinTLS](Azure.SQL.MinTLS.md) | Azure SQL Database servers should reject TLS versions older than 1.2. | Critical
 [Azure.SQL.TDE](Azure.SQL.TDE.md) | Use Transparent Data Encryption (TDE) with Azure SQL Database. | Critical
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable Advanced Thread Protection for Azure SQL logical server. | Important
 

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -10,6 +10,11 @@ Rule 'Azure.MySQL.UseSSL' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release =
     $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled');
 }
 
+# Synopsis: Consider configuring the minimum supported TLS version to be 1.2.
+Rule 'Azure.MySQL.MinTLS' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.minimalTlsVersion', 'TLS1_2');
+}
+
 # Synopsis: Determine if there is an excessive number of firewall rules
 Rule 'Azure.MySQL.FirewallRuleCount' -Type 'Microsoft.DBforMySQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules');

--- a/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
@@ -10,6 +10,11 @@ Rule 'Azure.PostgreSQL.UseSSL' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{
     $Assert.HasFieldValue($TargetObject, 'Properties.sslEnforcement', 'Enabled');
 }
 
+# Synopsis: Consider configuring the minimum supported TLS version to be 1.2.
+Rule 'Azure.PostgreSQL.MinTLS' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $Assert.HasFieldValue($TargetObject, 'Properties.minimalTlsVersion', 'TLS1_2');
+}
+
 # Synopsis: Determine if there is an excessive number of firewall rules
 Rule 'Azure.PostgreSQL.FirewallRuleCount' -Type 'Microsoft.DBforPostgreSQL/servers' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $firewallRules = @(GetSubResources -ResourceType 'Microsoft.DBforPostgreSQL/servers/firewallRules');

--- a/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
@@ -50,6 +50,11 @@ Rule 'Azure.SQL.AAD' -Type 'Microsoft.Sql/servers' -Tag @{ release = 'GA'; ruleS
     $Assert.HasFieldValue($config, 'Properties.administratorType', 'ActiveDirectory');
 }
 
+# Synopsis: Consider configuring the minimum supported TLS version to be 1.2.
+Rule 'Azure.SQL.MinTLS' -Type 'Microsoft.Sql/servers' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $Assert.Version($TargetObject, 'Properties.minimalTlsVersion', '>=1.2');
+}
+
 # Synopsis: Enable transparent data encryption
 Rule 'Azure.SQL.TDE' -Type 'Microsoft.Sql/servers/databases' -If { !(IsMasterDatabase) } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $config = GetSubResources -ResourceType 'Microsoft.Sql/servers/databases/transparentDataEncryption';

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -47,6 +47,22 @@ Describe 'Azure.MySQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'server-A', 'server-C';
+        }
+
+        It 'Azure.MySQL.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-B', 'server-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-A';
         }
@@ -64,8 +80,8 @@ Describe 'Azure.MySQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
 
         It 'Azure.MySQL.AllowAzureAccess' {
@@ -80,8 +96,8 @@ Describe 'Azure.MySQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
 
         It 'Azure.MySQL.FirewallIPRange' {
@@ -97,8 +113,8 @@ Describe 'Azure.MySQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
@@ -47,6 +47,22 @@ Describe 'Azure.PostgreSQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
+        }
+
+        It 'Azure.PostgreSQL.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.PostgreSQL.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-B', 'server-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-A';
         }
@@ -64,8 +80,8 @@ Describe 'Azure.PostgreSQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
 
         It 'Azure.PostgreSQL.AllowAzureAccess' {
@@ -80,8 +96,8 @@ Describe 'Azure.PostgreSQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
 
         It 'Azure.PostgreSQL.FirewallIPRange' {
@@ -97,8 +113,8 @@ Describe 'Azure.PostgreSQL' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'server-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-A', 'server-C';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
@@ -133,6 +133,22 @@ Describe 'Azure.SQL' {
             $ruleResult.TargetName | Should -Be 'server-A';
         }
 
+        It 'Azure.SQL.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SQL.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'server-B', 'server-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
+
         It 'Azure.SQL.TDE' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SQL.TDE' };
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
@@ -185,8 +185,48 @@
             },
             "version": "5.7",
             "sslEnforcement": "Enabled",
+            "minimalTlsVersion": "TLS1_2",
+            "publicNetworkAccess": "Enabled",
             "userVisibleState": "Ready",
             "fullyQualifiedDomainName": "server-A.mysql.database.azure.com",
+            "replicationRole": "None",
+            "masterServerId": "",
+            "replicaCapacity": 5
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.DBforMySQL/servers",
+        "ResourceType": "Microsoft.DBforMySQL/servers",
+        "Sku": {
+            "Name": "GP_Gen5_4",
+            "Tier": "GeneralPurpose",
+            "Size": null,
+            "Family": "Gen5",
+            "Model": null,
+            "Capacity": 4
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/servers/server-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/servers/server-C",
+        "Location": "region",
+        "ResourceName": "server-C",
+        "Name": "server-C",
+        "Properties": {
+            "administratorLogin": "db-admin",
+            "storageProfile": {
+                "storageMB": 5120,
+                "backupRetentionDays": 7,
+                "geoRedundantBackup": "Disabled",
+                "storageAutoGrow": "Disabled"
+            },
+            "version": "5.7",
+            "sslEnforcement": "Enabled",
+            "minimalTlsVersion": "TLS1_0",
+            "publicNetworkAccess": "Enabled",
+            "userVisibleState": "Ready",
+            "fullyQualifiedDomainName": "server-C.mysql.database.azure.com",
             "replicationRole": "None",
             "masterServerId": "",
             "replicaCapacity": 5

--- a/tests/PSRule.Rules.Azure.Tests/Resources.PostgreSQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.PostgreSQL.json
@@ -185,8 +185,48 @@
             },
             "version": "10",
             "sslEnforcement": "Enabled",
+            "minimalTlsVersion": "TLS1_2",
+            "publicNetworkAccess": "Enabled",
             "userVisibleState": "Ready",
             "fullyQualifiedDomainName": "server-A.postgres.database.azure.com",
+            "replicationRole": "None",
+            "masterServerId": "",
+            "replicaCapacity": 5
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.DBforPostgreSQL/servers",
+        "ResourceType": "Microsoft.DBforPostgreSQL/servers",
+        "Sku": {
+            "Name": "GP_Gen5_4",
+            "Tier": "GeneralPurpose",
+            "Size": null,
+            "Family": "Gen5",
+            "Model": null,
+            "Capacity": 4
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforPostgreSQL/servers/server-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforPostgreSQL/servers/server-C",
+        "Location": "region",
+        "ResourceName": "server-C",
+        "Name": "server-C",
+        "Properties": {
+            "administratorLogin": "dbadmin",
+            "storageProfile": {
+                "storageMB": 102400,
+                "backupRetentionDays": 7,
+                "geoRedundantBackup": "Disabled",
+                "storageAutoGrow": "Enabled"
+            },
+            "version": "10",
+            "sslEnforcement": "Enabled",
+            "minimalTlsVersion": "TLS1_0",
+            "publicNetworkAccess": "Enabled",
+            "userVisibleState": "Ready",
+            "fullyQualifiedDomainName": "server-c.postgres.database.azure.com",
             "replicationRole": "None",
             "masterServerId": "",
             "replicaCapacity": 5

--- a/tests/PSRule.Rules.Azure.Tests/Resources.SQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.SQL.json
@@ -16,6 +16,8 @@
             "externalAdministratorLogin": null,
             "externalAdministratorSid": null,
             "version": "12.0",
+            "minimalTlsVersion": "1.2",
+            "publicNetworkAccess": "Enabled",
             "state": "Ready"
         },
         "resources": [
@@ -140,6 +142,8 @@
             "externalAdministratorLogin": null,
             "externalAdministratorSid": null,
             "version": "12.0",
+            "minimalTlsVersion": "1.0",
+            "publicNetworkAccess": "Enabled",
             "state": "Ready"
         },
         "resources": [


### PR DESCRIPTION
## PR Summary

- New rules:
  - Database for MySQL:
    - Check database servers reject TLS versions older than 1.2. #469
  - Database for PostgreSQL:
    - Check database servers reject TLS versions older than 1.2. #470
  - SQL Database:
    - Check database servers reject TLS versions older than 1.2. #471

Fixes #469 
Fixes #470 
Fixes #471 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
