### PR TITLE
Pre-release v0.15.0-B2008043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.15.0-B2008043 (pre-release)
+
+What's changed since pre-release v0.15.0-B2008034:
+
 - New rules:
   - Database for MySQL:
     - Check database servers reject TLS versions older than 1.2. [#469](https://github.com/Microsoft/PSRule.Rules.Azure/issues/469)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.15.0-B2008034:

- New rules:
  - Database for MySQL:
    - Check database servers reject TLS versions older than 1.2. #469
  - Database for PostgreSQL:
    - Check database servers reject TLS versions older than 1.2. #470
  - SQL Database:
    - Check database servers reject TLS versions older than 1.2. #471
- Bug fixes:
  - Fixed use variables check when no variables are defined. #462

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
