### PR TITLE
Add CDN endpoint TLS and naming rule #486 #487

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- New rules:
+  - CDN:
+    - Check CDN endpoint naming requirements. [#486](https://github.com/Microsoft/PSRule.Rules.Azure/issues/486)
+    - Check CDN endpoints use TLS 1.2. [#487](https://github.com/Microsoft/PSRule.Rules.Azure/issues/487)
 - General improvements:
   - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. [#481](https://github.com/Microsoft/PSRule.Rules.Azure/issues/481)
   - Improve output of template processing exceptions. [#484](https://github.com/Microsoft/PSRule.Rules.Azure/issues/484)

--- a/docs/baselines/en/Azure.All.md
+++ b/docs/baselines/en/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 155 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 157 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -52,7 +52,9 @@ Name | Synopsis | Severity
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Azure App Service apps should only accept encrypted connections. | Important
 [Azure.Automation.EncryptVariables](Azure.Automation.EncryptVariables.md) | Azure Automation variables should be encrypted. | Important
 [Azure.Automation.WebHookExpiry](Azure.Automation.WebHookExpiry.md) | Do not create webhooks with an expiry time greater than 1 year (default). | Awareness
+[Azure.CDN.EndpointName](Azure.CDN.EndpointName.md) | Azure CDN Endpoint names should meet naming requirements. | Awareness
 [Azure.CDN.HTTP](Azure.CDN.HTTP.md) | Enforce HTTPS for client connections. | Important
+[Azure.CDN.MinTLS](Azure.CDN.MinTLS.md) | Azure CDN endpoints should reject TLS versions older than 1.2. | Important
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
 [Azure.Firewall.Mode](Azure.Firewall.Mode.md) | Deny high confidence malicious IP addresses and domains. | Critical
 [Azure.FrontDoor.Logs](Azure.FrontDoor.Logs.md) | Audit and monitor access through Front Door. | Important

--- a/docs/baselines/en/Azure.Default.md
+++ b/docs/baselines/en/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 153 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 155 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -50,7 +50,9 @@ Name | Synopsis | Severity
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Azure App Service apps should only accept encrypted connections. | Important
 [Azure.Automation.EncryptVariables](Azure.Automation.EncryptVariables.md) | Azure Automation variables should be encrypted. | Important
 [Azure.Automation.WebHookExpiry](Azure.Automation.WebHookExpiry.md) | Do not create webhooks with an expiry time greater than 1 year (default). | Awareness
+[Azure.CDN.EndpointName](Azure.CDN.EndpointName.md) | Azure CDN Endpoint names should meet naming requirements. | Awareness
 [Azure.CDN.HTTP](Azure.CDN.HTTP.md) | Enforce HTTPS for client connections. | Important
+[Azure.CDN.MinTLS](Azure.CDN.MinTLS.md) | Azure CDN endpoints should reject TLS versions older than 1.2. | Important
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
 [Azure.Firewall.Mode](Azure.Firewall.Mode.md) | Deny high confidence malicious IP addresses and domains. | Critical
 [Azure.FrontDoor.Logs](Azure.FrontDoor.Logs.md) | Audit and monitor access through Front Door. | Important

--- a/docs/baselines/en/Azure.Preview.md
+++ b/docs/baselines/en/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 155 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 157 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -52,7 +52,9 @@ Name | Synopsis | Severity
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Azure App Service apps should only accept encrypted connections. | Important
 [Azure.Automation.EncryptVariables](Azure.Automation.EncryptVariables.md) | Azure Automation variables should be encrypted. | Important
 [Azure.Automation.WebHookExpiry](Azure.Automation.WebHookExpiry.md) | Do not create webhooks with an expiry time greater than 1 year (default). | Awareness
+[Azure.CDN.EndpointName](Azure.CDN.EndpointName.md) | Azure CDN Endpoint names should meet naming requirements. | Awareness
 [Azure.CDN.HTTP](Azure.CDN.HTTP.md) | Enforce HTTPS for client connections. | Important
+[Azure.CDN.MinTLS](Azure.CDN.MinTLS.md) | Azure CDN endpoints should reject TLS versions older than 1.2. | Important
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Awareness
 [Azure.Firewall.Mode](Azure.Firewall.Mode.md) | Deny high confidence malicious IP addresses and domains. | Critical
 [Azure.FrontDoor.Logs](Azure.FrontDoor.Logs.md) | Audit and monitor access through Front Door. | Important

--- a/docs/rules/en/Azure.CDN.EndpointName.md
+++ b/docs/rules/en/Azure.CDN.EndpointName.md
@@ -1,0 +1,37 @@
+---
+severity: Awareness
+pillar: Operational Excellence
+category: Tagging and resource naming
+resource: Content Delivery Network
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.CDN.EndpointName.md
+---
+
+# Use valid CDN endpoint names
+
+## SYNOPSIS
+
+Azure CDN Endpoint names should meet naming requirements.
+
+## DESCRIPTION
+
+When naming Azure resources, resource names must meet service requirements.
+The requirements for CDN endpoint names are:
+
+- Between 1 and 50 characters long.
+- Alphanumerics and hyphens.
+- Start and end with a letter or number.
+- CDN endpoint names must be globally unique.
+
+## RECOMMENDATION
+
+Consider using names that meet CDN endpoint naming requirements.
+Additionally consider naming resources with a standard naming convention.
+
+## NOTES
+
+This rule does not check if CDN endpoint names are unique.
+
+## LINKS
+
+- [Naming rules and restrictions for Azure resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcdn)
+- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.cdn/profiles/endpoints)

--- a/docs/rules/en/Azure.CDN.MinTLS.md
+++ b/docs/rules/en/Azure.CDN.MinTLS.md
@@ -1,0 +1,32 @@
+---
+severity: Important
+pillar: Security
+category: Encryption
+resource: Content Delivery Network
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.CDN.MinTLS.md
+---
+
+# Azure CDN endpoint minimum TLS version
+
+## SYNOPSIS
+
+Azure CDN endpoints should reject TLS versions older than 1.2.
+
+## DESCRIPTION
+
+The minimum version of TLS that Azure CDN endpoints accept is configurable.
+Older TLS versions are no longer considered secure by industry standards, such as PCI DSS.
+
+Azure lets you disable outdated protocols and require connections to use a minimum of TLS 1.2.
+By default, TLS 1.0, TLS 1.1, and TLS 1.2 is accepted.
+
+To configure the minimum TLS version, a custom domain must be configured.
+
+## RECOMMENDATION
+
+Consider configuring a custom domain and setting the minimum supported TLS version to be 1.2.
+
+## LINKS
+
+- [Preparing for TLS 1.2 in Microsoft Azure](https://azure.microsoft.com/en-us/updates/azuretls12/)
+- [REST API Custom Domains - Enable Custom Https](https://docs.microsoft.com/en-us/rest/api/cdn/customdomains/enablecustomhttps#minimumtlsversion)

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -73,6 +73,7 @@ Name | Synopsis | Severity
 [Azure.APIM.APIDescriptors](Azure.APIM.APIDescriptors.md) | API Management APIs should have a display name and description. | Awareness
 [Azure.APIM.Name](Azure.APIM.Name.md) | API Management service names should meet naming requirements. | Awareness
 [Azure.APIM.ProductDescriptors](Azure.APIM.ProductDescriptors.md) | API Management products should have a display name and description. | Awareness
+[Azure.CDN.EndpointName](Azure.CDN.EndpointName.md) | Azure CDN Endpoint names should meet naming requirements. | Awareness
 [Azure.FrontDoor.Name](Azure.FrontDoor.Name.md) | Front Door names should meet naming requirements. | Awareness
 [Azure.LB.Name](Azure.LB.Name.md) | Load Balancer names should meet naming requirements. | Awareness
 [Azure.NSG.Name](Azure.NSG.Name.md) | Network Security Group (NSG) names should meet naming requirements. | Awareness
@@ -168,6 +169,7 @@ Name | Synopsis | Severity
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Azure App Service apps should only accept encrypted connections. | Important
 [Azure.Automation.EncryptVariables](Azure.Automation.EncryptVariables.md) | Azure Automation variables should be encrypted. | Important
 [Azure.CDN.HTTP](Azure.CDN.HTTP.md) | Enforce HTTPS for client connections. | Important
+[Azure.CDN.MinTLS](Azure.CDN.MinTLS.md) | Azure CDN endpoints should reject TLS versions older than 1.2. | Important
 [Azure.FrontDoor.MinTLS](Azure.FrontDoor.MinTLS.md) | Front Door should reject TLS versions older then 1.2. | Critical
 [Azure.MySQL.MinTLS](Azure.MySQL.MinTLS.md) | MySQL DB servers should reject TLS versions older than 1.2. | Critical
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Critical

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -115,7 +115,9 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.CDN.EndpointName](Azure.CDN.EndpointName.md) | Azure CDN Endpoint names should meet naming requirements. | Awareness
 [Azure.CDN.HTTP](Azure.CDN.HTTP.md) | Enforce HTTPS for client connections. | Important
+[Azure.CDN.MinTLS](Azure.CDN.MinTLS.md) | Azure CDN endpoints should reject TLS versions older than 1.2. | Important
 
 ### Data Factory
 

--- a/src/PSRule.Rules.Azure/rules/Azure.CDN.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.CDN.Rule.ps1
@@ -9,3 +9,33 @@
 Rule 'Azure.CDN.HTTP' -Type 'Microsoft.Cdn/profiles/endpoints' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $Assert.HasFieldValue($TargetObject, 'properties.isHttpAllowed', $False)
 }
+
+# Synopsis: Use CDN endpoint naming requirements
+Rule 'Azure.CDN.EndpointName' -Type 'Microsoft.Cdn/profiles/endpoints' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcdn
+
+    $nameParts = $PSRule.TargetName.Split('/');
+    $name = $nameParts[-1];
+
+    # Between 1 and 50 characters long
+    $Assert.GreaterOrEqual($name, '.', 1)
+    $Assert.LessOrEqual($name, '.', 50)
+
+    # Alphanumerics and hyphens.
+    # Start and end with alphanumeric.
+    $Assert.Match($name, '.', '^[a-zA-Z0-9](([a-zA-Z0-9]|-)*[a-zA-Z0-9]){0,49}$')
+}
+
+# Synopsis: Consider configuring the minimum supported TLS version to be 1.2.
+Rule 'Azure.CDN.MinTLS' -Type 'Microsoft.Cdn/profiles/endpoints', 'Microsoft.Cdn/profiles/endpoints/customdomains' -Tag @{ release = 'GA'; ruleSet = '2020_09' } {
+    $customDomains = @($TargetObject);
+    if ($PSRule.TargetType -eq 'Microsoft.Cdn/profiles/endpoints') {
+        $customDomains = @(GetSubResources -ResourceType 'Microsoft.Cdn/profiles/endpoints/customdomains');
+    }
+    if ($customDomains.Length -eq 0) {
+        return $Assert.Pass();
+    }
+    foreach ($customDomain in $customDomains) {
+        $Assert.HasFieldValue($customDomain, 'properties.customHttpsParameters.minimumTlsVersion', 'TLS12')
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.CDN.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.CDN.Tests.ps1
@@ -21,7 +21,7 @@ $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
-Describe 'Azure.CDN' {
+Describe 'Azure.CDN' -Tag 'CDN' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.CDN.json';
 
     Context 'Conditions' {
@@ -45,8 +45,69 @@ Describe 'Azure.CDN' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'cdn-endpoint-B', 'cdn-endpoint-C';
+        }
+
+        It 'Azure.CDN.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.CDN.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cdn-endpoint-B';
+            $ruleResult.TargetName | Should -Be 'cdn-endpoint-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'cdn-endpoint-A', 'cdn-endpoint-B';
+        }
+    }
+
+    Context 'Resource name' {
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $validNames = @(
+            'endpoint-001'
+            'ENDPOINT001'
+        )
+        $invalidNames = @(
+            '_endpoint1'
+            '-endpoint1'
+            'endpoint1_'
+            'endpointy1-'
+            'endpoint.1'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        )
+        $testObject = [PSCustomObject]@{
+            Name = ''
+            ResourceType = 'Microsoft.Cdn/profiles/endpoints'
+        }
+
+        # Pass
+        foreach ($name in $validNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.CDN.EndpointName';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Pass';
+            }
+        }
+
+        # Fail
+        foreach ($name in $invalidNames) {
+            It $name {
+                $testObject.Name = $name;
+                $ruleResult = $testObject | Invoke-PSRule @invokeParams -Name 'Azure.CDN.EndpointName';
+                $ruleResult | Should -Not -BeNullOrEmpty;
+                $ruleResult.Outcome | Should -Be 'Fail';
+            }
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.CDN.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.CDN.json
@@ -175,6 +175,193 @@
         "ResourceType": "Microsoft.Cdn/profiles/endpoints",
         "Sku": null,
         "Tags": {},
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": [
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-B/customdomains/custom-domain-B",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-B/customdomains/custom-domain-B",
+                "Identity": null,
+                "Kind": null,
+                "Location": null,
+                "ManagedBy": null,
+                "ResourceName": "custom-domain-B",
+                "Name": "custom-domain-B",
+                "ExtensionResourceName": null,
+                "ParentResource": null,
+                "Plan": null,
+                "Properties": {
+                    "provisioningState": "Succeeded",
+                    "resourceState": "Active",
+                    "hostName": "host.contoso.com",
+                    "validationData": null,
+                    "customHttpsProvisioningState": "Enabled",
+                    "customHttpsProvisioningSubstate": "CertificateDeployed",
+                    "customHttpsParameters": {
+                        "certificateSource": "AzureKeyVault",
+                        "certificateSourceParameters": {
+                            "@odata.type": "#Microsoft.Azure.Cdn.Models.KeyVaultCertificateSourceParameters",
+                            "subscriptionId": "00000000-0000-0000-0000-000000000000",
+                            "resourceGroupName": "rg-test",
+                            "vaultName": "vault-B",
+                            "secretName": "secret-B",
+                            "secretVersion": "00000000000000000000000000000000",
+                            "updateRule": "NoAction",
+                            "deleteRule": "NoAction"
+                        },
+                        "minimumTlsVersion": "TLS12",
+                        "protocolType": "ServerNameIndication"
+                    }
+                },
+                "ResourceGroupName": "rg-test",
+                "Type": "Microsoft.Cdn/profiles/endpoints/customdomains",
+                "ResourceType": "Microsoft.Cdn/profiles/endpoints/customdomains",
+                "ExtensionResourceType": null,
+                "Sku": null,
+                "Tags": null,
+                "TagsTable": null,
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "CreatedTime": null,
+                "ChangedTime": null,
+                "ETag": null
+            }
+        ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-C",
+        "Identity": null,
+        "Kind": null,
+        "Location": "Global",
+        "ManagedBy": null,
+        "ResourceName": "cdn-endpoint-C",
+        "Name": "cdn-endpoint-C",
+        "Plan": null,
+        "Properties": {
+            "hostName": "cdn-endpoint-C.azureedge.net",
+            "originHostHeader": "origin-C",
+            "provisioningState": "Succeeded",
+            "resourceState": "Running",
+            "isHttpAllowed": false,
+            "isHttpsAllowed": true,
+            "queryStringCachingBehavior": "IgnoreQueryString",
+            "originPath": null,
+            "origins": [
+                {
+                    "name": "origin-C",
+                    "properties": {
+                        "hostName": "origin-C",
+                        "httpPort": 80,
+                        "httpsPort": 443
+                    }
+                }
+            ],
+            "customDomains": [],
+            "contentTypesToCompress": [
+                "application/eot",
+                "application/font",
+                "application/font-sfnt",
+                "application/javascript",
+                "application/json",
+                "application/opentype",
+                "application/otf",
+                "application/pkcs7-mime",
+                "application/truetype",
+                "application/ttf",
+                "application/vnd.ms-fontobject",
+                "application/xhtml+xml",
+                "application/xml",
+                "application/xml+rss",
+                "application/x-font-opentype",
+                "application/x-font-truetype",
+                "application/x-font-ttf",
+                "application/x-httpd-cgi",
+                "application/x-javascript",
+                "application/x-mpegurl",
+                "application/x-opentype",
+                "application/x-otf",
+                "application/x-perl",
+                "application/x-ttf",
+                "font/eot",
+                "font/ttf",
+                "font/otf",
+                "font/opentype",
+                "image/svg+xml",
+                "text/css",
+                "text/csv",
+                "text/html",
+                "text/javascript",
+                "text/js",
+                "text/plain",
+                "text/richtext",
+                "text/tab-separated-values",
+                "text/xml",
+                "text/x-script",
+                "text/x-component",
+                "text/x-java-source"
+            ],
+            "isCompressionEnabled": true,
+            "optimizationType": "GeneralWebDelivery",
+            "probePath": null,
+            "geoFilters": [],
+            "deliveryPolicy": {
+                "description": "",
+                "rules": []
+            }
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "Microsoft.Cdn/profiles/endpoints",
+        "ResourceType": "Microsoft.Cdn/profiles/endpoints",
+        "Sku": null,
+        "Tags": {},
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": [
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-C/customdomains/custom-domain-C",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.Cdn/profiles/cdn-A/endpoints/cdn-endpoint-C/customdomains/custom-domain-C",
+                "Identity": null,
+                "Kind": null,
+                "Location": null,
+                "ManagedBy": null,
+                "ResourceName": "custom-domain-C",
+                "Name": "custom-domain-C",
+                "ExtensionResourceName": null,
+                "ParentResource": null,
+                "Plan": null,
+                "Properties": {
+                    "provisioningState": "Succeeded",
+                    "resourceState": "Active",
+                    "hostName": "host.contoso.com",
+                    "validationData": null,
+                    "customHttpsProvisioningState": "Enabled",
+                    "customHttpsProvisioningSubstate": "CertificateDeployed",
+                    "customHttpsParameters": {
+                        "certificateSource": "AzureKeyVault",
+                        "certificateSourceParameters": {
+                            "@odata.type": "#Microsoft.Azure.Cdn.Models.KeyVaultCertificateSourceParameters",
+                            "subscriptionId": "00000000-0000-0000-0000-000000000000",
+                            "resourceGroupName": "rg-test",
+                            "vaultName": "vault-B",
+                            "secretName": "secret-B",
+                            "secretVersion": "00000000000000000000000000000000",
+                            "updateRule": "NoAction",
+                            "deleteRule": "NoAction"
+                        },
+                        "minimumTlsVersion": "TLS10",
+                        "protocolType": "ServerNameIndication"
+                    }
+                },
+                "ResourceGroupName": "rg-test",
+                "Type": "Microsoft.Cdn/profiles/endpoints/customdomains",
+                "ResourceType": "Microsoft.Cdn/profiles/endpoints/customdomains",
+                "ExtensionResourceType": null,
+                "Sku": null,
+                "Tags": null,
+                "TagsTable": null,
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+                "CreatedTime": null,
+                "ChangedTime": null,
+                "ETag": null
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## PR Summary

- Check CDN endpoint naming requirements. #486 
- Check CDN endpoints use TLS 1.2. #487

Fixes #486 
Fixes #487 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
