### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ What's changed since v0.15.0:
   - Fixed parameter file detection with `2019-04-01` schema. [#495](https://github.com/microsoft/PSRule.Rules.Azure/issues/495)
   - Fixed deprecated `$Rule` properties. [#491](https://github.com/microsoft/PSRule.Rules.Azure/issues/491)
 
-What's changed since pre-release v0.16.0-B2009024:
+What's changed since pre-release v0.16.0-B2009033:
 
 - No additional changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+## v0.16.0
+
+What's changed since v0.15.0:
+
+- New features:
+  - Added `Azure.GA_2020_09` baseline. [#488](https://github.com/Microsoft/PSRule.Rules.Azure/issues/488)
+    - Includes rules released before or during September 2020 for Azure GA features.
+    - Marked baseline `Azure.GA_2020_06` as obsolete.
+- New rules:
+  - CDN:
+    - Check CDN endpoint naming requirements. [#486](https://github.com/Microsoft/PSRule.Rules.Azure/issues/486)
+    - Check CDN endpoints use TLS 1.2. [#487](https://github.com/Microsoft/PSRule.Rules.Azure/issues/487)
+- Updated rules:
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to 1.18.8. [#504](https://github.com/Microsoft/PSRule.Rules.Azure/issues/504)
+- General improvements:
+  - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. [#481](https://github.com/Microsoft/PSRule.Rules.Azure/issues/481)
+  - Improve output of template processing exceptions. [#484](https://github.com/Microsoft/PSRule.Rules.Azure/issues/484)
+- Engineering:
+  - Bump PSRule dependency to v0.20.0.
+- Bug fixes:
+  - Fixed Data Factory version not detected with template. [#498](https://github.com/microsoft/PSRule.Rules.Azure/issues/498)
+  - Fixed parameter file detection with `2019-04-01` schema. [#495](https://github.com/microsoft/PSRule.Rules.Azure/issues/495)
+  - Fixed deprecated `$Rule` properties. [#491](https://github.com/microsoft/PSRule.Rules.Azure/issues/491)
+
+What's changed since pre-release v0.16.0-B2009024:
+
+- No additional changes.
+
 ## v0.16.0-B2009033 (pre-release)
 
 What's changed since pre-release v0.16.0-B2009024:
@@ -20,7 +49,7 @@ What's changed since pre-release v0.16.0-B2009024:
 
 What's changed since pre-release v0.16.0-B2009019:
 
-- Bug fixed:
+- Bug fixes:
   - Fixed Data Factory version not detected with template. [#498](https://github.com/microsoft/PSRule.Rules.Azure/issues/498)
 
 ## v0.16.0-B2009019 (pre-release)


### PR DESCRIPTION
## PR Summary

What's changed since v0.15.0:

- New features:
  - Added `Azure.GA_2020_09` baseline. #488
    - Includes rules released before or during September 2020 for Azure GA features.
    - Marked baseline `Azure.GA_2020_06` as obsolete.
- New rules:
  - CDN:
    - Check CDN endpoint naming requirements. #486
    - Check CDN endpoints use TLS 1.2. #487
- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to 1.18.8. #504
- General improvements:
  - Updated rule content to align with Microsoft Azure Well-Architected Framework pillars. #481
  - Improve output of template processing exceptions. #484
- Engineering:
  - Bump PSRule dependency to v0.20.0.
- Bug fixes:
  - Fixed Data Factory version not detected with template. #498
  - Fixed parameter file detection with `2019-04-01` schema. #495
  - Fixed deprecated `$Rule` properties. #491

What's changed since pre-release v0.16.0-B2009033:

- No additional changes.


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

