### PR TITLE
Pre-release v0.17.0-B2010006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.17.0-B2010006 (pre-release)
+
+What's changed since pre-release v0.17.0-B2009009:
+
 - New rules:
   - App Configuration:
     - Check App Configuration stores meet name requirements. [#528](https://github.com/Microsoft/PSRule.Rules.Azure/issues/528)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.17.0-B2009009:

- New rules:
  - App Configuration:
    - Check App Configuration stores meet name requirements. #528
    - Check App Configuration stores use standard SKU. #528
  - App Service:
    - Check App Service apps use Always On. #521
    - Check App Service apps have remote debugging disabled. #521
    - Check App Service apps use newer .NET Framework versions. #521
    - Check App Service apps use newer PHP runtime versions. #521
  - Logic App:
    - Check Logic App apps limit IP range for HTTP triggers. #526
- Updated rules:
  - Azure Kubernetes Service:
    - Promote `Azure.AKS.AzurePolicyAddOn` to GA rule set. #524
- Removed rules:
  - Azure Kubernetes Service:
    - Remove `Azure.AKS.PodSecurityPolicy` as this AKS feature is replaced by Azure Policy. #523

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
