### PR TITLE
Update app service and storage rules #533 #534 #535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Updated rules:
+  - Storage:
+    - Updated `Azure.Storage.UseReplication` for additional use cases.
+      - Added support for geo-zone-redundant storage. [#535](https://github.com/Microsoft/PSRule.Rules.Azure/issues/534)
+      - Exclude storage tagged with `resource-usage = 'azure-functions'` or `resource-usage = 'azure-monitor'`. [#534](https://github.com/Microsoft/PSRule.Rules.Azure/issues/534)
+- Bug fixes:
+  - Fixed App Service rule site config false positives in templates. [#533](https://github.com/Microsoft/PSRule.Rules.Azure/issues/533)
+
 ## v0.17.0-B2010006 (pre-release)
 
 What's changed since pre-release v0.17.0-B2009009:

--- a/docs/baselines/en/Azure.All.md
+++ b/docs/baselines/en/Azure.All.md
@@ -126,7 +126,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness
 [Azure.Template.Resources](Azure.Template.Resources.md) | Each Azure Resource Manager (ARM) template file should deploy at least one resource. | Awareness

--- a/docs/baselines/en/Azure.Default.md
+++ b/docs/baselines/en/Azure.Default.md
@@ -126,7 +126,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness
 [Azure.Template.Resources](Azure.Template.Resources.md) | Each Azure Resource Manager (ARM) template file should deploy at least one resource. | Awareness

--- a/docs/baselines/en/Azure.GA_2020_06.md
+++ b/docs/baselines/en/Azure.GA_2020_06.md
@@ -108,7 +108,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.TemplateFile](Azure.Template.TemplateFile.md) | Use ARM template files that are valid. | Important
 [Azure.TrafficManager.Endpoints](Azure.TrafficManager.Endpoints.md) | Traffic Manager should use at lest two enabled endpoints. | Important

--- a/docs/baselines/en/Azure.GA_2020_09.md
+++ b/docs/baselines/en/Azure.GA_2020_09.md
@@ -118,7 +118,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness
 [Azure.Template.Resources](Azure.Template.Resources.md) | Each Azure Resource Manager (ARM) template file should deploy at least one resource. | Awareness

--- a/docs/baselines/en/Azure.Preview.md
+++ b/docs/baselines/en/Azure.Preview.md
@@ -126,7 +126,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 [Azure.Template.ParameterFile](Azure.Template.ParameterFile.md) | Use ARM template parameter files that are valid. | Important
 [Azure.Template.ParameterMetadata](Azure.Template.ParameterMetadata.md) | Set metadata descriptions in Azure Resource Manager (ARM) template for each parameter. | Awareness
 [Azure.Template.Resources](Azure.Template.Resources.md) | Each Azure Resource Manager (ARM) template file should deploy at least one resource. | Awareness

--- a/docs/rules/en/Azure.Storage.UseReplication.md
+++ b/docs/rules/en/Azure.Storage.UseReplication.md
@@ -10,11 +10,21 @@ online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/r
 
 ## SYNOPSIS
 
-Storage accounts not using geo-replicated storage (GRS) may be at risk.
+Storage Accounts not using geo-replicated storage (GRS) may be at risk.
 
 ## DESCRIPTION
 
-Storage accounts can be configured with several different durability options.
+Storage Accounts can be configured with several different durability options.
+Azure provides a number of geo-replicated options including;
+Geo-redundant storage and geo-zone-redundant storage.
+Geo-zone-redundant storage is only available in supported regions.
+
+The following geo-replicated options are available within Azure:
+
+- `Standard_GRS`
+- `Standard_RAGRS`
+- `Standard_GZRS`
+- `Standard_RAGZRS`
 
 ## RECOMMENDATION
 
@@ -22,9 +32,16 @@ Consider using GRS for storage accounts that contain data.
 
 ## NOTES
 
-Cloud Shell storage with the tag `ms-resource-usage = 'azure-cloud-shell'` is excluded.
-Storage accounts used for Cloud Shell are not intended to store data.
+Storage Accounts with the following tags are automatically excluded from this rule:
+
+- `ms-resource-usage = 'azure-cloud-shell'` - Storage Accounts used for Cloud Shell are not intended to store data.
+This tag is applied by Azure to Cloud Shell Storage Accounts by default.
+- `resource-usage = 'azure-functions'` - Storage Accounts used for Azure Functions.
+This tag can be optionally configured.
+- `resource-usage = 'azure-monitor'` - Storage Accounts used by Azure Monitor are intended for diagnostic logs.
+This tag can be optionally configured.
 
 ## LINKS
 
-- [Azure Storage redundancy](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy)
+- [Azure Storage redundancy](https://docs.microsoft.com/azure/storage/common/storage-redundancy)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.storage/storageaccounts)

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -145,7 +145,7 @@ Name | Synopsis | Severity
 [Azure.KeyVault.PurgeProtect](Azure.KeyVault.PurgeProtect.md) | Enable Purge Protection on Key Vaults to prevent early purge of vaults and vault items. | Important
 [Azure.KeyVault.SoftDelete](Azure.KeyVault.SoftDelete.md) | Enable Soft Delete on Key Vaults to protect vaults and vault items from accidental deletion. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 
 ### Load balancing and failover
 

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -261,7 +261,7 @@ Name | Synopsis | Severity
 [Azure.Storage.SecureTransfer](Azure.Storage.SecureTransfer.md) | Storage accounts should only accept encrypted connections. | Important
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts. | Important
 [Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled. | Important
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using geo-replicated storage (GRS) may be at risk. | Important
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 
 ### Subscription
 

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -60,18 +60,6 @@ function global:IsExport {
     }
 }
 
-function global:IsCloudShell {
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param ()
-    process {
-        if ($PSRule.TargetType -ne 'Microsoft.Storage/storageAccounts') {
-            return $False;
-        }
-        return $TargetObject.Tags.'ms-resource-usage' -eq 'azure-cloud-shell';
-    }
-}
-
 function global:HasPeerNetwork {
     [CmdletBinding()]
     [OutputType([System.Boolean])]

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -177,4 +177,86 @@ Describe 'Azure.AppService' -Tag 'AppService' {
             $ruleResult.TargetName | Should -Be 'site-A', 'site-A/staging';
         }
     }
+
+    Context 'With Template' {
+        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AppService.json;
+        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.AppService.Parameters.json' | Export-AzTemplateRuleData -OutputPath $outputFile;
+        $invokeParams = @{
+            Baseline = 'Azure.All'
+            Module = 'PSRule.Rules.Azure'
+            WarningAction = 'Ignore'
+            ErrorAction = 'Stop'
+        }
+        $result = Invoke-PSRule @invokeParams -InputPath $outputFile -Outcome All;
+
+        It 'Azure.AppService.MinTLS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.MinTLS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-a';
+        }
+
+        It 'Azure.AppService.RemoteDebug' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.RemoteDebug' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-a';
+        }
+
+        It 'Azure.AppService.NETVersion' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.NETVersion' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-a';
+        }
+
+        It 'Azure.AppService.PHPVersion' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.PHPVersion' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-a';
+        }
+
+        It 'Azure.AppService.AlwaysOn' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.AlwaysOn' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'app-a';
+        }
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -39,8 +39,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'storage-B', 'storage-C';
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'storage-B';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -51,8 +51,8 @@ Describe 'Azure.Storage' -Tag Storage {
             # None
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-D', 'storage-C';
         }
 
         It 'Azure.Storage.SecureTransfer' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "./Resources.AppService.Template.json"
+    },
+    "parameters": {
+        "appName": {
+            "value": "app-a"
+        },
+        "planName": {
+            "value": "plan-a"
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AppService.Template.json
@@ -1,0 +1,229 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "name": "App Service",
+        "description": "Create or update an App Service Web App."
+    },
+    "parameters": {
+        "appName": {
+            "type": "string"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The Azure region to deploy to."
+            }
+        },
+        "planName": {
+            "type": "string"
+        },
+        "alwaysOn": {
+            "type": "bool",
+            "defaultValue": true
+        },
+        "skuCode": {
+            "type": "string",
+            "allowedValues": [
+                "S1",
+                "S2",
+                "S3"
+            ],
+            "defaultValue": "S1"
+        },
+        "currentStack": {
+            "type": "string",
+            "defaultValue": "dotnetcore"
+        },
+        "slots": {
+            "type": "array",
+            "defaultValue": [
+            ]
+        },
+        "appClientId": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "appTenantId": {
+            "type": "string",
+            "defaultValue": "[subscription().tenantId]"
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {
+            },
+            "metadata": {
+                "description": "Tags to apply to the resource."
+            }
+        }
+    },
+    "variables": {
+        "useAuth": "[not(empty(parameters('appClientId')))]",
+        "aadAuth": {
+            "true": {
+                "enabled": true,
+                "unauthenticatedClientAction": "RedirectToLoginPage",
+                "tokenStoreEnabled": null,
+                "allowedExternalRedirectUrls": null,
+                "defaultProvider": "AzureActiveDirectory",
+                "clientId": "[parameters('appClientId')]",
+                "clientSecret": null,
+                "clientSecretCertificateThumbprint": null,
+                "issuer": "[concat('https://sts.windows.net/', parameters('appTenantId'))]",
+                "allowedAudiences": null,
+                "additionalLoginParams": null,
+                "isAadAutoProvisioned": false,
+                "googleClientId": null,
+                "googleClientSecret": null,
+                "googleOAuthScopes": null,
+                "facebookAppId": null,
+                "facebookAppSecret": null,
+                "facebookOAuthScopes": null,
+                "twitterConsumerKey": null,
+                "twitterConsumerSecret": null,
+                "microsoftAccountClientId": null,
+                "microsoftAccountClientSecret": null,
+                "microsoftAccountOAuthScopes": null
+            },
+            "false": null
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2018-11-01",
+            "name": "[parameters('appName')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "dependsOn": [
+                "[concat('microsoft.insights/components/', parameters('appName'))]",
+                "[concat('Microsoft.Web/serverfarms/', parameters('planName'))]"
+            ],
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(concat('microsoft.insights/components/', parameters('appName')), '2015-05-01').InstrumentationKey]"
+                        },
+                        {
+                            "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                            "value": "[reference(concat('microsoft.insights/components/', parameters('appName')), '2015-05-01').ConnectionString]"
+                        },
+                        {
+                            "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
+                            "value": "~2"
+                        },
+                        {
+                            "name": "XDT_MicrosoftApplicationInsights_Mode",
+                            "value": "default"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "name": "CURRENT_STACK",
+                            "value": "[parameters('currentStack')]"
+                        }
+                    ],
+                    "phpVersion": "OFF",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "siteAuthEnabled": "[variables('useAuth')]",
+                    "siteAuthSettings": "[variables('aadAuth')[string(variables('useAuth'))]]"
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', parameters('planName'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
+        },
+        {
+            "condition": "[not(empty(parameters('slots')))]",
+            "name": "[concat(parameters('appName'), '/', if(empty(parameters('slots')), 'empty', parameters('slots')[copyIndex('slotCount')]))]",
+            "type": "Microsoft.Web/sites/slots",
+            "apiVersion": "2018-11-01",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "copy": {
+                "name": "slotCount",
+                "count": "[length(parameters('slots'))]",
+                "mode": "Parallel"
+            },
+            "dependsOn": [
+                "[concat('microsoft.insights/components/', parameters('appName'))]",
+                "[concat('Microsoft.Web/serverfarms/', parameters('planName'))]",
+                "[concat('Microsoft.Web/sites/', parameters('appName'))]"
+            ],
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(concat('microsoft.insights/components/', parameters('appName')), '2015-05-01').InstrumentationKey]"
+                        },
+                        {
+                            "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                            "value": "[reference(concat('microsoft.insights/components/', parameters('appName')), '2015-05-01').ConnectionString]"
+                        },
+                        {
+                            "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
+                            "value": "~2"
+                        },
+                        {
+                            "name": "XDT_MicrosoftApplicationInsights_Mode",
+                            "value": "default"
+                        }
+                    ],
+                    "metadata": [
+                        {
+                            "name": "CURRENT_STACK",
+                            "value": "[parameters('currentStack')]"
+                        }
+                    ],
+                    "phpVersion": "OFF",
+                    "alwaysOn": "[parameters('alwaysOn')]",
+                    "minTlsVersion": "1.2",
+                    "siteAuthEnabled": "[variables('useAuth')]",
+                    "siteAuthSettings": "[variables('aadAuth')[string(variables('useAuth'))]]"
+                },
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', parameters('planName'))]",
+                "clientAffinityEnabled": false,
+                "httpsOnly": true
+            }
+        },
+        {
+            "apiVersion": "2018-11-01",
+            "name": "[parameters('planName')]",
+            "type": "Microsoft.Web/serverfarms",
+            "location": "[parameters('location')]",
+            "kind": "",
+            "tags": "[parameters('tags')]",
+            "dependsOn": [
+            ],
+            "properties": {
+                "name": "[parameters('planName')]"
+            },
+            "sku": {
+                "Name": "[parameters('skuCode')]",
+                "capacity": 1
+            }
+        },
+        {
+            "apiVersion": "2015-05-01",
+            "name": "[parameters('appName')]",
+            "type": "microsoft.insights/components",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('tags')]",
+            "properties": {
+                "ApplicationId": "[parameters('appName')]",
+                "Request_Source": "IbizaWebAppExtensionCreate"
+            }
+        }
+    ],
+    "outputs": {
+        "url": {
+            "type": "string",
+            "value": "[concat('https://', reference(resourceId('Microsoft.Web/sites', parameters('appName')), '2018-11-01').defaultHostName, '/')]"
+        }
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
@@ -142,7 +142,7 @@
                 "file": "https://storage-B.file.core.windows.net/"
             },
             "primaryLocation": "region",
-            "statusOfPrimary": "available",
+            "statusOfPrimary": "available"
         },
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Storage/storageAccounts",
@@ -254,7 +254,9 @@
             "Model": null,
             "Capacity": null
         },
-        "Tags": null,
+        "Tags": {
+            "resource-usage": "azure-functions"
+        },
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {


### PR DESCRIPTION
## PR Summary

- Updated rules:
  - Storage:
    - Updated `Azure.Storage.UseReplication` for additional use cases.
      - Added support for geo-zone-redundant storage. #535
      - Exclude storage tagged with `resource-usage = 'azure-functions'` or `resource-usage = 'azure-monitor'`. #534
- Bug fixes:
  - Fixed App Service rule site config false positives in templates. #533

Fixes #533 
Fixes #534 
Fixes #535 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
