### PR TITLE
Pre-release v0.17.0-B2010028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+## v0.17.0-B2010028 (pre-release)
+
+What's changed since pre-release v0.17.0-B2010022:
+
 - New rules:
   - Azure Cache for Redis:
-    - Check cache instances Standard C1 or greater. [#501](https://github.com/microsoft/PSRule.Rules.Azure/issues/501)
+    - Check cache instances use Standard C1 or greater SKU. [#501](https://github.com/microsoft/PSRule.Rules.Azure/issues/501)
     - Cache cache instances configure `maxmemory-reserved` setting. [#502](https://github.com/microsoft/PSRule.Rules.Azure/issues/502)
 
 ## v0.17.0-B2010022 (pre-release)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.17.0-B2010022:

- New rules:
  - Azure Cache for Redis:
    - Check cache instances use Standard C1 or greater SKU. #501
    - Cache cache instances configure `maxmemory-reserved` setting. #502

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
