### PR TITLE
Fixed reason string and template link path handling #567 #568

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.18.0-B2011005:
+
+- Bug fixes:
+  - Fixed reason typo on template parameter metadata. [#567](https://github.com/microsoft/PSRule.Rules.Azure/issues/567)
+  - Fixed `Get-AzRuleTemplateLink` reports incorrect parameter with file path. [#568](https://github.com/microsoft/PSRule.Rules.Azure/issues/568)
+
 ## v0.18.0-B2011005 (pre-release)
 
 What's changed since pre-release v0.18.0-B2010016:

--- a/src/PSRule.Rules.Azure/Configuration/PSRuleOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/PSRuleOption.cs
@@ -74,7 +74,7 @@ namespace PSRule.Rules.Azure.Configuration
             if (rootedPath.Length > 0 && IsSeparator(rootedPath[rootedPath.Length - 1]))
                 return rootedPath;
 
-            return string.Concat(rootedPath, Path.DirectorySeparatorChar);
+            return File.Exists(rootedPath) ? rootedPath : string.Concat(rootedPath, Path.DirectorySeparatorChar);
         }
 
         [DebuggerStepThrough]

--- a/src/PSRule.Rules.Azure/Pipeline/PathBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PathBuilder.cs
@@ -71,6 +71,9 @@ namespace PSRule.Rules.Azure.Pipeline
                 return;
 
             var pathLiteral = GetSearchParameters(path, out string searchPattern, out SearchOption searchOption);
+            if (TryAddFile(pathLiteral))
+                return;
+
             var files = Directory.EnumerateFiles(pathLiteral, searchPattern, searchOption);
             foreach (var file in files)
                 AddFile(file);

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -32,7 +32,7 @@
     UnmanagedSubscription = "The subscription is not managed."
     DBServerFirewallRuleCount = "The number of firewall rules ({0}) exceeded {1}."
     DBServerFirewallPublicIPRange = "The number of public IP addresses permitted ({0}) exceeded {1}."
-    TemplateParameterDescription = "The parameter '{0}' does not name a description set."
+    TemplateParameterDescription = "The parameter '{0}' does not have a description set."
     ParameterNotFound = "The parameter '{0}' was not used within the template."
     VariableNotFound = "The variable '{0}' was not used within the template."
     AssessmentUnhealthy = "An assessment is reporting one or more issues."


### PR DESCRIPTION
## PR Summary

- Bug fixes:
  - Fixed reason typo on template parameter metadata. #567
  - Fixed `Get-AzRuleTemplateLink` reports incorrect parameter with file path. #568

Fixes #567 
Fixes #568 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [ ] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
