### PR TITLE
Added support for true false and null template functions #579

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since v0.18.0:
+
+- General improvements:
+  - Added support for `true`, `false`, and `null` template functions. [#579](https://github.com/Microsoft/PSRule.Rules.Azure/issues/579)
+
 ## v0.18.0
 
 What's changed since v0.17.0:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -64,7 +64,6 @@ namespace PSRule.Rules.Azure.Data.Template
                     fnParams.Add(Inner(stream));
                 }
                 var aParams = fnParams.ToArray();
-
                 result = (context) => descriptor.Invoke(context, aParams);
 
                 while (stream.TryTokenType(ExpressionTokenType.IndexStart, out ExpressionToken token) || stream.TryTokenType(ExpressionTokenType.Property, out token))

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -64,9 +64,11 @@ namespace PSRule.Rules.Azure.Data.Template
             // Logical
             new FunctionDescriptor("and", And),
             new FunctionDescriptor("bool", Bool),
+            new FunctionDescriptor("false", False),
             new FunctionDescriptor("if", If),
             new FunctionDescriptor("not", Not),
             new FunctionDescriptor("or", Or),
+            new FunctionDescriptor("true", True),
 
             // Numeric
             new FunctionDescriptor("add", Add),
@@ -82,6 +84,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             // Object
             new FunctionDescriptor("json", Json),
+            new FunctionDescriptor("null", Null),
 
             // Resource
             new FunctionDescriptor("extensionResourceId", ExtensionResourceId),
@@ -304,6 +307,17 @@ namespace PSRule.Rules.Azure.Data.Template
                 throw new ArgumentOutOfRangeException();
 
             return JsonConvert.DeserializeObject(json);
+        }
+
+        /// <summary>
+        /// null()
+        /// </summary>
+        internal static object Null(TemplateContext context, object[] args)
+        {
+            if (CountArgs(args) > 0)
+                throw ArgumentsOutOfRange(nameof(Null), args);
+
+            return null;
         }
 
         internal static object Last(TemplateContext context, object[] args)
@@ -1110,6 +1124,17 @@ namespace PSRule.Rules.Azure.Data.Template
         }
 
         /// <summary>
+        /// false()
+        /// </summary>
+        internal static object False(TemplateContext context, object[] args)
+        {
+            if (CountArgs(args) > 0)
+                throw ArgumentsOutOfRange(nameof(False), args);
+
+            return false;
+        }
+
+        /// <summary>
         /// if(condition, trueValue, falseValue)
         /// </summary>
         internal static object If(TemplateContext context, object[] args)
@@ -1147,6 +1172,17 @@ namespace PSRule.Rules.Azure.Data.Template
                     return true;
             }
             return false;
+        }
+
+        /// <summary>
+        /// true()
+        /// </summary>
+        internal static object True(TemplateContext context, object[] args)
+        {
+            if (CountArgs(args) > 0)
+                throw ArgumentsOutOfRange(nameof(True), args);
+
+            return true;
         }
 
         #endregion Logical

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -196,6 +196,19 @@ namespace PSRule.Rules.Azure
 
         [Fact]
         [Trait(TRAIT, TRAIT_ARRAY)]
+        public void Null()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.Null(context, null);
+            var actual2 = Functions.Null(context, new object[] { });
+
+            Assert.Null(actual1);
+            Assert.Null(actual2);
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
         public void Last()
         {
             var context = GetContext();
@@ -810,6 +823,20 @@ namespace PSRule.Rules.Azure
 
         [Fact]
         [Trait(TRAIT, TRAIT_LOGICAL)]
+        public void False()
+        {
+            var context = GetContext();
+
+            var actual1 = (bool)Functions.False(context, null);
+            var actual2 = (bool)Functions.False(context, new object[] { });
+            Assert.False(actual1);
+            Assert.False(actual2);
+
+            Assert.Throws<ExpressionArgumentException>(() => Functions.False(context, new object[] { "true" }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LOGICAL)]
         public void If()
         {
             var context = GetContext();
@@ -844,6 +871,20 @@ namespace PSRule.Rules.Azure
             Assert.True(actual1);
             Assert.True(actual2);
             Assert.False(actual3);
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_LOGICAL)]
+        public void True()
+        {
+            var context = GetContext();
+
+            var actual1 = (bool)Functions.True(context, null);
+            var actual2 = (bool)Functions.True(context, new object[] { });
+            Assert.True(actual1);
+            Assert.True(actual2);
+
+            Assert.Throws<ExpressionArgumentException>(() => Functions.True(context, new object[] { "true" }));
         }
 
         #endregion Logical
@@ -896,8 +937,6 @@ namespace PSRule.Rules.Azure
             var actual2 = (float)Functions.Float(context, new object[] { "3.0" });
             Assert.Equal(3.0f, actual2);
 
-            // String
-
             Assert.Throws<ExpressionArgumentException>(() => Functions.Float(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Float(context, new object[] { }));
             Assert.Throws<FormatException>(() => Functions.Float(context, new object[] { "one" }));
@@ -916,8 +955,6 @@ namespace PSRule.Rules.Azure
             // String
             var actual2 = (int)Functions.Int(context, new object[] { "4" });
             Assert.Equal(4, actual2);
-
-            // String
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, new object[] { }));

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -100,7 +100,7 @@
             "comments": "Hub virtual network",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('VNETName')]",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2020-06-01",
             "location": "region-A",
             "dependsOn": [
                 "routeIndex",
@@ -177,6 +177,7 @@
             }
         },
         {
+            "condition": "[empty(null())]",
             "comments": "A subnet Route Table",
             "type": "Microsoft.Network/routeTables",
             "name": "[concat('route-', parameters('subnets')[copyIndex('routeIndex')].name)]",
@@ -187,7 +188,7 @@
                 "count": "[length(parameters('subnets'))]"
             },
             "properties": {
-                "disableBgpRoutePropagation": false,
+                "disableBgpRoutePropagation": "[false()]",
                 "routes": "[variables('routes')]"
             }
         },
@@ -208,6 +209,7 @@
             }
         },
         {
+            "condition": "[true()]",
             "comments": "A subnet Network Security Group",
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[concat('nsg-', parameters('subnets')[copyIndex()].name)]",


### PR DESCRIPTION
## PR Summary

- Added support for `true`, `false`, and `null` template functions. #579

Fixes #579 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
