### PR TITLE
Added support for createObject function #580

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ What's changed since v0.18.0:
 
 - General improvements:
   - Added support for `true`, `false`, and `null` template functions. [#579](https://github.com/Microsoft/PSRule.Rules.Azure/issues/579)
+  - Added support for `createObject` template function. [#580](https://github.com/Microsoft/PSRule.Rules.Azure/issues/580)
 
 ## v0.18.0
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -31,6 +31,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("concat", Concat),
             new FunctionDescriptor("contains", Contains),
             new FunctionDescriptor("createArray", CreateArray),
+            new FunctionDescriptor("createObject", CreateObject),
             new FunctionDescriptor("empty", Empty),
             new FunctionDescriptor("first", First),
             new FunctionDescriptor("intersection", Intersection),
@@ -239,12 +240,35 @@ namespace PSRule.Rules.Azure.Data.Template
             return false;
         }
 
+        /// <summary>
+        /// createArray (arg1, arg2, arg3, ...)
+        /// </summary>
         internal static object CreateArray(TemplateContext context, object[] args)
         {
             if (CountArgs(args) < 1)
                 throw ArgumentsOutOfRange(nameof(CreateArray), args);
 
             return new JArray(args);
+        }
+
+        /// <summary>
+        /// createObject(key1, value1, key2, value2, ...)
+        /// </summary>
+        internal static object CreateObject(TemplateContext context, object[] args)
+        {
+            var argCount = CountArgs(args);
+            if (argCount < 2 || argCount % 2 != 0)
+                throw ArgumentsOutOfRange(nameof(CreateObject), args);
+
+            var properties = new JProperty[argCount / 2];
+            for (var i = 0; i < argCount / 2; i++)
+            {
+                if (!ExpressionHelpers.TryString(args[i * 2], out string name))
+                    throw ArgumentInvalidString(nameof(CreateObject), $"key{i + 1}");
+
+                properties[i] = new JProperty(name, args[i * 2 + 1]);
+            }
+            return new JObject(properties);
         }
 
         internal static object First(TemplateContext context, object[] args)

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -271,6 +271,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 9;
             $result[0].name | Should -Be 'vnet-001';
+            $result[0].properties.addressSpace.addressPrefixes | Should -Be "10.1.0.0/24";
             $result[0].properties.subnets.Length | Should -Be 3;
             $result[0].properties.subnets[0].name | Should -Be 'GatewaySubnet';
             $result[0].properties.subnets[0].properties.addressPrefix | Should -Be '10.1.0.0/27';

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -117,6 +117,31 @@ namespace PSRule.Rules.Azure
 
         [Fact]
         [Trait(TRAIT, TRAIT_ARRAY)]
+        public void CreateObject()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.CreateObject(context, new object[] {
+                "intProp", 1,
+                "stringProp", "abc",
+                "boolProp", true,
+                "arrayProp", Functions.CreateArray(context, new object[] { "a", "b", "c" }),
+                "objectProp", Functions.CreateObject(context, new object[] { "key1", "value1" }),
+            }) as JObject;
+
+            Assert.Equal(1, actual1["intProp"]);
+            Assert.Equal("abc", actual1["stringProp"]);
+            Assert.Equal(true, actual1["boolProp"]);
+            Assert.Equal("b", actual1["arrayProp"][1]);
+            Assert.Equal("value1", actual1["objectProp"]["key1"]);
+
+            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, null));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { }));
+            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateObject(context, new object[] { "intProp", 1, "stringProp" }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
         public void Empty()
         {
             var context = GetContext();

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -93,7 +93,8 @@
                     "properties": {}
                 }
             }
-        ]
+        ],
+        "vnetAddressSpace": "[createObject('addressPrefixes', Parameters('addressPrefix'))]"
     },
     "resources": [
         {
@@ -107,9 +108,7 @@
                 "nsgIndex"
             ],
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": "[Parameters('addressPrefix')]"
-                },
+                "addressSpace": "[variables('vnetAddressSpace')]",
                 "subnets": "[variabLes('AllSubnets')]"
             },
             "tags": {


### PR DESCRIPTION
## PR Summary

- Added support for `createObject` template function. #580

Fixes #580 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
