### PR TITLE
Pre-release v0.19.0-B2012008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.19.0-B2012008 (pre-release)
+
+What's changed since pre-release v0.19.0-B2011008:
+
 - Updated rules:
   - Azure Kubernetes Service:
     - Updated `Azure.AKS.Version` to 1.19.3. [#590](https://github.com/Microsoft/PSRule.Rules.Azure/issues/590)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.19.0-B2011008:

- Updated rules:
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to 1.19.3. #590
- Engineering:
  - Bump PSRule dependency to v1.0.0. #588

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
