### PR TITLE
Fixed Azure.FrontDoor.ProbePath reason #617

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since pre-release v1.0.0-B2101006:
+
+- Bug fixes:
+  - Fixed reason `Azure.FrontDoor.ProbePath` so the probe name is included. [#617](https://github.com/Microsoft/PSRule.Rules.Azure/issues/617)
+
 ## v1.0.0-B2101006 (pre-release)
 
 What's changed since v0.19.0:

--- a/docs/rules/en/Azure.FrontDoor.Probe.md
+++ b/docs/rules/en/Azure.FrontDoor.Probe.md
@@ -27,6 +27,21 @@ Health probes allow Front Door to select a backend endpoint able to respond to t
 
 Consider enabling a health probe for each Front Door backend endpoint.
 
+## EXAMPLES
+
+### Configure with Azure CLI
+
+```bash
+az network front-door probe update --front-door-name '<front_door>' -n '<probe_name>' -g '<resource_group>' --enabled 'Enabled'
+```
+
+### Configure with Azure PowerShell
+
+```powershell
+$probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -EnabledState 'Enabled'
+Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
 ## LINKS
 
 - [Health probes](https://docs.microsoft.com/azure/frontdoor/front-door-health-probes)

--- a/docs/rules/en/Azure.FrontDoor.ProbeMethod.md
+++ b/docs/rules/en/Azure.FrontDoor.ProbeMethod.md
@@ -22,6 +22,21 @@ To lower load and performance cost against backends use HEAD requests.
 
 Consider configuring health probes to query backend health endpoints using HEAD requests.
 
+## EXAMPLES
+
+### Configure with Azure CLI
+
+```bash
+az network front-door probe update --front-door-name '<front_door>' -n '<probe_name>' -g '<resource_group>' --probeMethod  'HEAD'
+```
+
+### Configure with Azure PowerShell
+
+```powershell
+$probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -HealthProbeMethod 'HEAD'
+Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
 ## LINKS
 
 - [Supported HTTP methods for health probes](https://docs.microsoft.com/en-gb/azure/frontdoor/front-door-health-probes#supported-http-methods-for-health-probes)

--- a/docs/rules/en/Azure.FrontDoor.ProbePath.md
+++ b/docs/rules/en/Azure.FrontDoor.ProbePath.md
@@ -24,6 +24,21 @@ Regular checks of the monitored path allow Front Door to make load balancing dec
 
 Consider using a dedicated health probe endpoint that implements functional checks.
 
+## EXAMPLES
+
+### Configure with Azure CLI
+
+```bash
+az network front-door probe update --front-door-name '<front_door>' -n '<probe_name>' -g '<resource_group>' --path '<path>'
+```
+
+### Configure with Azure PowerShell
+
+```powershell
+$probeSetting = New-AzFrontDoorHealthProbeSettingObject -Name '<probe_name>' -Path '<path>'
+Set-AzFrontDoor -Name '<front_door>' -ResourceGroupName '<resource_group>' -HealthProbeSetting $probeSetting
+```
+
 ## LINKS
 
 - [Health probes](https://docs.microsoft.com/azure/frontdoor/front-door-health-probes)

--- a/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en/PSRule-rules.psd1
@@ -37,4 +37,5 @@
     VariableNotFound = "The variable '{0}' was not used within the template."
     AssessmentUnhealthy = "An assessment is reporting one or more issues."
     AssessmentNotFound = "The results for a valid assessment was not found."
+    HealthProbeNotDedicated = "The health probe '{0}' used the default path '/'."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.FrontDoor.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.FrontDoor.Rule.ps1
@@ -66,7 +66,7 @@ Rule 'Azure.FrontDoor.ProbePath' -Type 'Microsoft.Network/frontdoors', 'Microsof
         $probes = @($TargetObject.Properties.healthProbeSettings);
     }
     foreach ($probe in $probes) {
-        $Assert.NotIn($probe, 'properties.path', '/');
+        $Assert.NotIn($probe, 'properties.path', '/').Reason($LocalizedData.HealthProbeNotDedicated, $probe.name);
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
@@ -121,6 +121,7 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'frontdoor-B';
+            $ruleResult[0].Reason | Should -BeLike "The health probe '*' used the default path '/'.";
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });


### PR DESCRIPTION
## PR Summary

- Fixed reason `Azure.FrontDoor.ProbePath` so the probe name is included.

Fixes #617

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
