### PR TITLE
Rename cmdlet Export-AzTemplateRuleData #596

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+What's changed since pre-release v1.0.0-B2101016:
+
+- General improvements:
+  - Renamed `Export-AzTemplateRuleData` to `Export-AzRuleTemplateData`. [#596](https://github.com/Microsoft/PSRule.Rules.Azure/issues/596)
+    - New name `Export-AzRuleTemplateData` aligns with prefix of other cmdlets.
+    - Use of `Export-AzTemplateRuleData` is now deprecated and will be removed in the next major version.
+    - Added alias to allow `Export-AzTemplateRuleData` to continue to be used.
+    - Using `Export-AzTemplateRuleData` returns a deprecation warning.
+
 ## v1.0.0-B2101016 (pre-release)
 
 What's changed since pre-release v1.0.0-B2101006:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
 
     # STEP 2: Export template data for analysis
     - name: Export templates
-      run: Install-Module PSRule.Rules.Azure -Force; Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath 'out/templates/';
+      run: Install-Module PSRule.Rules.Azure -Force; Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath 'out/templates/';
       shell: pwsh
 
     # STEP 3: Run analysis against exported data
@@ -131,7 +131,7 @@ jobs:
       module: 'PSRule.Rules.Azure'   # Install PSRule.Rules.Azure from the PowerShell Gallery.
 
   # STEP 4: Export template data for analysis
-  - powershell: Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath 'out/templates/';
+  - powershell: Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath 'out/templates/';
     displayName: 'Export template data'
 
   # STEP 5: Run analysis against exported data
@@ -158,7 +158,7 @@ For example:
 Install-Module -Name 'PSRule.Rules.Azure' -Scope CurrentUser;
 
 # STEP 2: Export template data for analysis
-Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath 'out/templates/';
+Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath 'out/templates/';
 
 # STEP 3: Run analysis against exported data
 Assert-PSRule -Module 'PSRule.Rules.Azure' -InputPath 'out/templates/';
@@ -320,7 +320,7 @@ PSRule for Azure extends PowerShell with the following cmdlets.
 The following commands exist in the `PSRule.Rules.Azure` module:
 
 - [Export-AzRuleData](docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleData.md) - Export resource configuration data from Azure subscriptions.
-- [Export-AzTemplateRuleData](docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md) - Export resource configuration data from Azure templates.
+- [Export-AzRuleTemplateData](docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleTemplateData.md) - Export resource configuration data from Azure templates.
 - [Get-AzRuleTemplateLink](docs/commands/PSRule.Rules.Azure/en-US/Get-AzRuleTemplateLink.md) - Get a metadata link to a Azure template file.
 
 ### Concepts

--- a/docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleTemplateData.md
+++ b/docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleTemplateData.md
@@ -1,11 +1,11 @@
 ---
 external help file: PSRule.Rules.Azure-help.xml
 Module Name: PSRule.Rules.Azure
-online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleTemplateData.md
 schema: 2.0.0
 ---
 
-# Export-AzTemplateRuleData
+# Export-AzRuleTemplateData
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Export resource configuration data from Azure templates.
 ## SYNTAX
 
 ```text
-Export-AzTemplateRuleData [[-Name] <String>] -TemplateFile <String> [-ParameterFile <String[]>]
+Export-AzRuleTemplateData [[-Name] <String>] -TemplateFile <String> [-ParameterFile <String[]>]
  [-ResourceGroupName <String>] [-Subscription <String>] [-OutputPath <String>] [-PassThru] [<CommonParameters>]
 ```
 
@@ -46,7 +46,7 @@ A placeholder value is used instead.
 ### Example 1
 
 ```powershell
-Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json;
+Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json;
 ```
 
 Export resource configuration data based on merging a template and parameter file together.

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,7 +30,7 @@ Pre-flight validation can be integrated into a continuous integration (CI) pipel
 
 PSRule for Azure provides the following cmdlets that extract data for analysis:
 
-- [Export-AzTemplateRuleData](commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md) - Used for pre-flight analysis of one or more ARM templates.
+- [Export-AzRuleTemplateData](commands/PSRule.Rules.Azure/en-US/Export-AzRuleTemplateData.md) - Used for pre-flight analysis of one or more ARM templates.
 - [Export-AzRuleData](commands/PSRule.Rules.Azure/en-US/Export-AzRuleData.md) - Used for in-flight analysis of resources deployed to one or more Azure subscriptions.
 
 ## Cross-platform
@@ -63,7 +63,7 @@ For general FAQ see [PSRule - Frequently Asked Questions (FAQ)][ps-rule-faq], in
 The default built-in _Reader_ role to a subscription is required for:
 
 - Exporting rule data with `Export-AzRuleData`.
-- Exporting rule data from templates with `Export-AzTemplateRuleData` when online features are used.
+- Exporting rule data from templates with `Export-AzRuleTemplateData` when online features are used.
   - Optionally `-ResourceGroupName` and `-Subscription` parameter can be used; these require access _Reader_ access.
 
 ### What permissions do I need to analyze exported data?

--- a/docs/scenarios/azure-pipelines-ci/azure-pipelines-ci.md
+++ b/docs/scenarios/azure-pipelines-ci/azure-pipelines-ci.md
@@ -103,13 +103,13 @@ PSRule provides a pre-built cmdlets for finding template files within a path and
 - `Get-AzRuleTemplateLink` finds linked templates from parameter files.
 By default, parameter files with the `*.parameters.json` extension are discovered.
 Files are found recursively from the current working path.
-- `Export-AzTemplateRuleData` exports resource data from template files.
+- `Export-AzRuleTemplateData` exports resource data from template files.
 
 To generate data for analysis use a PowerShell YAML task to export resource data from linked templates.
 
 ```yaml
 # Export resource data from parameter files within the current working directory.
-- powershell: Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath out/templates/;
+- powershell: Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath out/templates/;
   displayName: 'Export template data'
 ```
 
@@ -117,7 +117,7 @@ If parameter files are located in a specific sub-directory the path can be updat
 
 ```yaml
 # Export resource data from parameter files in the deployments/ sub-directory.
-- powershell: Get-AzRuleTemplateLink ./deployments/ | Export-AzTemplateRuleData -OutputPath out/templates/;
+- powershell: Get-AzRuleTemplateLink ./deployments/ | Export-AzRuleTemplateData -OutputPath out/templates/;
   displayName: 'Export template data'
 ```
 
@@ -125,7 +125,7 @@ If parameter files do not use the file extension `.parameters.json` input path c
 
 ```yaml
 # Export resource data from parameter files ending in *.json instead of default *.parameters.json.
-- powershell: Get-AzRuleTemplateLink -InputPath *.json | Export-AzTemplateRuleData -OutputPath out/templates/;
+- powershell: Get-AzRuleTemplateLink -InputPath *.json | Export-AzRuleTemplateData -OutputPath out/templates/;
   displayName: 'Export template data'
 ```
 
@@ -200,7 +200,7 @@ steps:
     module: PSRule.Rules.Azure   # Install PSRule.Rules.Azure from the PowerShell Gallery.
 
 # Export resource data from parameter files within the current working directory.
-- powershell: Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath out/templates/;
+- powershell: Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath out/templates/;
   displayName: 'Export template data'
 
 # Run analysis from JSON files using the `PSRule.Rules.Azure` module and custom rules from `.ps-rule/`.

--- a/docs/scenarios/azure-pipelines-ci/azure-pipelines.yaml
+++ b/docs/scenarios/azure-pipelines-ci/azure-pipelines.yaml
@@ -16,7 +16,7 @@ steps:
     module: PSRule.Rules.Azure   # Install PSRule.Rules.Azure from the PowerShell Gallery.
 
 # Export resource data from parameter files within the current working directory.
-- powershell: Get-AzRuleTemplateLink | Export-AzTemplateRuleData -OutputPath out/templates/;
+- powershell: Get-AzRuleTemplateLink | Export-AzRuleTemplateData -OutputPath out/templates/;
   displayName: 'Export template data'
 
 # Run analysis from JSON files using the `PSRule.Rules.Azure` module and custom rules from `.ps-rule/`.

--- a/docs/scenarios/azure-template-ci/azure-template-ci.md
+++ b/docs/scenarios/azure-template-ci/azure-template-ci.md
@@ -77,14 +77,14 @@ See the [change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/C
 
 ## Exporting rule data for analysis
 
-In PSRule, the `Export-AzTemplateRuleData` cmdlet resolves a template and returns a resultant set of resources.
+In PSRule, the `Export-AzRuleTemplateData` cmdlet resolves a template and returns a resultant set of resources.
 The resultant set of resources can then be validated.
 
-No connectivity to Azure is required by default when calling `Export-AzTemplateRuleData`.
+No connectivity to Azure is required by default when calling `Export-AzRuleTemplateData`.
 
 ### Export cmdlet parameters
 
-To run `Export-AzTemplateRuleData` two key parameters are required:
+To run `Export-AzRuleTemplateData` two key parameters are required:
 
 - `-TemplateFile` - An absolute or relative path to the template JSON file.
 - `-ParameterFile` - An absolute or relative path to one or more parameter JSON files.
@@ -108,18 +108,18 @@ If `-OutputPath` is a directory or is not set, the output file will be automatic
 For example:
 
 ```powershell
-Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json;
+Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json;
 ```
 
 Multiple parameter files that map to the same template can be supplied in a single cmdlet call.
-Additional templates can be exported by calling `Export-AzTemplateRuleData` multiple times.
+Additional templates can be exported by calling `Export-AzRuleTemplateData` multiple times.
 
 ### Use of placeholder values
 
 A number of functions that can be used within Azure templates retrieve information from Azure.
 Some examples include `reference`, `subscription`, `resourceGroup`, `list*`.
 
-The default for `Export-AzTemplateRuleData` is to operate without requiring authenticated connectivity to Azure.
+The default for `Export-AzRuleTemplateData` is to operate without requiring authenticated connectivity to Azure.
 As a result, functions that retrieve information from Azure use placeholders such as `{{Subscription.SubscriptionId}}`.
 
 To provide a real value for `subscription` and `resourceGroup` use the `-Subscription` and `-ResourceGroup` parameters.
@@ -246,7 +246,7 @@ if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion '0.1
 }
 
 # Resolve resources
-Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
+Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
 
 # Validate resources
 $assertParams = @{
@@ -279,7 +279,7 @@ task InstallPSRule {
 # Synopsis: Run validation
 task ValidateTemplate InstallPSRule, {
     # Resolve resources
-    Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
+    Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
 
     # Validate resources
     $assertParams = @{
@@ -319,7 +319,7 @@ For example:
 Describe 'Azure' {
     Context 'Resource templates' {
         It 'Use content rules' {
-            Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath .\out\resources.json;
+            Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath .\out\resources.json;
 
             # Validate resources
             $invokeParams = @{

--- a/docs/scenarios/azure-template-ci/validate-template.ps1
+++ b/docs/scenarios/azure-template-ci/validate-template.ps1
@@ -11,7 +11,7 @@ if ($Null -eq (Get-InstalledModule -Name PSRule.Rules.Azure -MinimumVersion '0.1
 }
 
 # Resolve resources
-Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
+Export-AzRuleTemplateData -TemplateFile .\template.json -ParameterFile .\parameters.json -OutputPath out/;
 
 # Validate resources
 $assertParams = @{

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
@@ -77,7 +77,7 @@ RequiredAssemblies = @(
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
     'Export-AzRuleData'
-    'Export-AzTemplateRuleData'
+    'Export-AzRuleTemplateData'
     'Get-AzRuleTemplateLink'
 )
 
@@ -88,7 +88,9 @@ CmdletsToExport = @()
 VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @()
+AliasesToExport = @(
+    'Export-AzTemplateRuleData'
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -91,7 +91,7 @@ function Export-AzRuleData {
 }
 
 # .ExternalHelp PSRule.Rules.Azure-help.xml
-function Export-AzTemplateRuleData {
+function Export-AzRuleTemplateData {
     [CmdletBinding()]
     [OutputType([System.IO.FileInfo])]
     [OutputType([PSObject])]
@@ -119,7 +119,10 @@ function Export-AzTemplateRuleData {
         [Switch]$PassThru = $False
     )
     begin {
-        Write-Verbose -Message '[Export-AzTemplateRuleData] BEGIN::';
+        Write-Verbose -Message '[Export-AzRuleTemplateData] BEGIN::';
+        if ($MyInvocation.InvocationName -eq 'Export-AzTemplateRuleData') {
+            Write-Warning -Message "The cmdlet 'Export-AzTemplateRuleData' is has been renamed to 'Export-AzRuleTemplateData'. Use of 'Export-AzTemplateRuleData' is deprecated and will be removed in the next major version."
+        }
 
         $Option = [PSRule.Rules.Azure.Configuration.PSRuleOption]::new();
         $Option.Output.Path = $OutputPath;
@@ -175,7 +178,7 @@ function Export-AzTemplateRuleData {
                 $pipeline.Dispose();
             }
         }
-        Write-Verbose -Message '[Export-AzTemplateRuleData] END::';
+        Write-Verbose -Message '[Export-AzRuleTemplateData] END::';
     }
 }
 
@@ -1155,8 +1158,14 @@ function SetResourceType {
 # Export module
 #
 
+New-Alias -Name 'Export-AzTemplateRuleData' -Value 'Export-AzRuleTemplateData' -Force;
+
 Export-ModuleMember -Function @(
     'Export-AzRuleData'
-    'Export-AzTemplateRuleData'
+    'Export-AzRuleTemplateData'
     'Get-AzRuleTemplateLink'
+);
+
+Export-ModuleMember -Alias @(
+    'Export-AzTemplateRuleData'
 );

--- a/tests/Integration/QuickStartTemplate.Tests.ps1
+++ b/tests/Integration/QuickStartTemplate.Tests.ps1
@@ -105,7 +105,7 @@ Describe 'Azure Quickstart Templates' -Tag integration {
                 continue;
             }
             It "$($sample.Name)" {
-                $result = Export-AzTemplateRuleData -TemplateFile $sample.TemplateFile -ParameterFile $sample.ParametersFile -OutputPath .\out\ -PassThru;
+                $result = Export-AzRuleTemplateData -TemplateFile $sample.TemplateFile -ParameterFile $sample.ParametersFile -OutputPath .\out\ -PassThru;
                 $result | Should -Not -BeNullOrEmpty;
             }
         }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -298,7 +298,7 @@ Describe 'Azure.AKS' -Tag AKS {
     Context 'With Template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.AKS.Template.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AKS.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
         $invokeParams = @{
             Baseline = 'Azure.All'
             Module = 'PSRule.Rules.Azure'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -212,7 +212,7 @@ Describe 'Azure.AppService' -Tag 'AppService' {
 
     Context 'With Template' {
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.AppService.json;
-        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.AppService.Parameters.json' | Export-AzTemplateRuleData -OutputPath $outputFile;
+        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.AppService.Parameters.json' | Export-AzRuleTemplateData -OutputPath $outputFile;
         $invokeParams = @{
             Baseline = 'Azure.All'
             Module = 'PSRule.Rules.Azure'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.FrontDoor.Tests.ps1
@@ -274,7 +274,7 @@ Describe 'Azure.FrontDoor' -Tag 'Network', 'FrontDoor' {
     Context 'With template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template3.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.FrontDoor.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.FrontDoor.State' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.KeyVault.Tests.ps1
@@ -104,7 +104,7 @@ Describe 'Azure.KeyVault' -Tag 'KeyVault' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template2.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters2.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.KeyVault.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.KeyVault.SoftDelete' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Policy.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Policy.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'Azure.Policy' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Policy.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Policy.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Policy.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.Policy.Descriptors' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
@@ -179,7 +179,7 @@ Describe 'Azure.PublicIP' {
     Context 'With template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template3.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.PublicIP.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.PublicIP.IsAttached' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'Azure.Resource' -Tag 'Resource' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Resource.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $option = New-PSRuleOption -BaselineConfiguration @{ 'Azure_AllowedRegions' = @('region-A') };
         $invokeParams = @{
             Baseline = 'Azure.All'

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ServiceFabric.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ServiceFabric.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Azure.ServiceFabric' -Tag 'ServiceFabric' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.ServiceFabric.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.ServiceFabric.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.ServiceFabric.AAD' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -218,7 +218,7 @@ Describe 'Azure.Storage' -Tag Storage {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Storage.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Storage.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Storage.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop -Culture 'en-US';
 
         It 'Azure.Storage.UseReplication' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
@@ -848,7 +848,7 @@ Describe 'Azure.VM' {
     Context 'With template' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.VirtualMachine.Template.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.VirtualMachine.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.VM.UseManagedDisks' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -228,7 +228,7 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.VirtualNetwork.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop -Culture 'en-US';
 
         It 'Azure.VNET.UseNSGs' {
@@ -688,7 +688,7 @@ Describe 'Azure.NSG' -Tag 'Network', 'NSG' {
         $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
         $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.VirtualNetwork.json;
-        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        Export-AzRuleTemplateData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.NSG.AnyInboundSource' {
@@ -940,7 +940,7 @@ Describe 'Azure.VNG' -Tag 'Network', 'VNG', 'VPN', 'ExpressRoute' {
 
     Context 'With template' {
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.VPN.json;
-        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.VPN.Parameters.json' | Export-AzTemplateRuleData -OutputPath $outputFile;
+        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.VPN.Parameters.json' | Export-AzRuleTemplateData -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.VNG.VPNLegacySKU' {
@@ -972,7 +972,7 @@ Describe 'Azure.VNG' -Tag 'Network', 'VNG', 'VPN', 'ExpressRoute' {
         }
 
         $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.ExpressRoute.json;
-        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.ExpressRoute.Parameters.json' | Export-AzTemplateRuleData -OutputPath $outputFile;
+        Get-AzRuleTemplateLink -Path $here -InputPath 'Resources.ExpressRoute.Parameters.json' | Export-AzRuleTemplateData -OutputPath $outputFile;
         $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.VNG.ERLegacySKU' {

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -252,9 +252,9 @@ Describe 'Export-AzRuleData' -Tag 'Cmdlet','Export-AzRuleData' {
 
 #endregion Export-AzRuleData
 
-#region Export-AzTemplateRuleData
+#region Export-AzRuleTemplateData
 
-Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
+Describe 'Export-AzRuleTemplateData' -Tag 'Cmdlet','Export-AzRuleTemplateData' {
     $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
     $parametersPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
 
@@ -266,7 +266,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
                 ParameterFile = $parametersPath
                 OutputPath = $outputFile
             }
-            $Null = Export-AzTemplateRuleData @exportParams;
+            $Null = Export-AzRuleTemplateData @exportParams;
             $result = Get-Content -Path $outputFile -Raw | ConvertFrom-Json;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 9;
@@ -289,13 +289,13 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             # Invalid template file
             $exportParams['TemplateFile'] = 'notafile.json';
             $exportParams['ParameterFile'] = $parametersPath;
-            $errorOut = { $Null = Export-AzTemplateRuleData @exportParams -ErrorVariable exportErrors -ErrorAction SilentlyContinue; $exportErrors; } | Should -Throw -PassThru;
+            $errorOut = { $Null = Export-AzRuleTemplateData @exportParams -ErrorVariable exportErrors -ErrorAction SilentlyContinue; $exportErrors; } | Should -Throw -PassThru;
             $errorOut[0].Exception.Message | Should -BeLike "Unable to find the specified template file '*'.";
 
             # Invalid parameter file
             $exportParams['TemplateFile'] = $templatePath;
             $exportParams['ParameterFile'] = 'notafile.json';
-            $errorOut = { $Null = Export-AzTemplateRuleData @exportParams -ErrorVariable exportErrors -ErrorAction SilentlyContinue; $exportErrors; } | Should -Throw -PassThru;
+            $errorOut = { $Null = Export-AzRuleTemplateData @exportParams -ErrorVariable exportErrors -ErrorAction SilentlyContinue; $exportErrors; } | Should -Throw -PassThru;
             $errorOut[0].Exception.Message | Should -BeLike "Unable to find the specified parameter file '*'.";
         }
     }
@@ -306,7 +306,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
                 TemplateFile = $templatePath
                 ParameterFile = $parametersPath
             }
-            $result = @(Export-AzTemplateRuleData @exportParams -PassThru);
+            $result = @(Export-AzRuleTemplateData @exportParams -PassThru);
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 9;
             $result[0].name | Should -Be 'vnet-001';
@@ -334,7 +334,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
                 ParameterFile = $parametersPath
                 Subscription = 'test-sub'
             }
-            $result = Export-AzTemplateRuleData @exportParams -PassThru;
+            $result = Export-AzRuleTemplateData @exportParams -PassThru;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 9;
             $result[0].properties.subnets.Length | Should -Be 3;
@@ -361,7 +361,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
                 ParameterFile = $parametersPath
                 ResourceGroupName = 'test-rg'
             }
-            $result = Export-AzTemplateRuleData @exportParams -PassThru;
+            $result = Export-AzRuleTemplateData @exportParams -PassThru;
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 9;
             $result[0].properties.subnets.Length | Should -Be 3;
@@ -369,9 +369,23 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             $result[0].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/routeTables/route-subnet2$';
         }
     }
+
+    Context 'With Export-AzTemplateRuleData alias' {
+        It 'Returns warning' {
+            $outputFile = Join-Path -Path $outputPath -ChildPath 'template-with-defaults.json'
+            $exportParams = @{
+                TemplateFile = $templatePath
+                ParameterFile = $parametersPath
+                OutputPath = $outputFile
+            }
+            $Null = Export-AzTemplateRuleData @exportParams -WarningAction SilentlyContinue -WarningVariable warnings;
+            $warningMessages = @($warnings);
+            $warningMessages.Length | Should -Be 1;
+        }
+    }
 }
 
-#endregion Export-AzTemplateRuleData
+#endregion Export-AzRuleTemplateData
 
 #region Get-AzRuleTemplateLink
 


### PR DESCRIPTION
## PR Summary

- Renamed `Export-AzTemplateRuleData` to `Export-AzRuleTemplateData`.
  - New name `Export-AzRuleTemplateData` aligns with prefix of other cmdlets.
  - Use of `Export-AzTemplateRuleData` is now deprecated and will be removed in the next major version.
  - Added alias to allow `Export-AzTemplateRuleData` to continue to be used.
  - Using `Export-AzTemplateRuleData` returns a deprecation warning.

Fixes #596 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/CHANGELOG.md) has been updated with change under unreleased section
