### PR TITLE
Pre-release v1.0.0-B2101028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.0-B2101028 (pre-release)
+
 What's changed since pre-release v1.0.0-B2101016:
 
 - New rules:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A suite of rules to validate Azure resources and infrastructure as code (IaC) us
 
 Features of PSRule for Azure include:
 
-- [Ready to go](docs/features.md#ready-to-go) - Leverage over 100 pre-built rules to validate Azure resources.
+- [Ready to go](docs/features.md#ready-to-go) - Leverage over 180 pre-built rules to validate Azure resources.
 - [DevOps](docs/features.md#devops) - Validate resources and infrastructure code pre or post-deployment.
 - [Cross-platform](docs/features.md#cross-platform) - Run on MacOS, Linux, and Windows.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@ The following sections describe key features of PSRule for Azure.
 
 ## Ready to go
 
-PSRule for Azure includes over 100 rules for validating resources against configuration recommendations.
+PSRule for Azure includes over 180 rules for validating resources against configuration recommendations.
 Each rule includes additional information to help remediate issues.
 
 Use the built-in rules to start enforcing release processes quickly.


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.0.0-B2101016:

- New rules:
  - All resources:
    - Check parameter default value type matches type. #311
- General improvements:
  - Renamed `Export-AzTemplateRuleData` to `Export-AzRuleTemplateData`. #596
    - New name `Export-AzRuleTemplateData` aligns with prefix of other cmdlets.
    - Use of `Export-AzTemplateRuleData` is now deprecated and will be removed in the next major version.
    - Added alias to allow `Export-AzTemplateRuleData` to continue to be used.
    - Using `Export-AzTemplateRuleData` returns a deprecation warning.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
