### PR TITLE
Fixed Azure.VM.ADE to limit rule to exports #644

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since pre-release v1.1.0-B2102001:
+
+- Bug fixes:
+  - Fixed `Azure.VM.ADE` to limit rule to exports only. [#644](https://github.com/microsoft/PSRule.Rules.Azure/issues/644)
+
 ## v1.1.0-B2102001 (pre-release)
 
 What's changed since v1.0.0:

--- a/docs/rules/en/Azure.VM.ADE.md
+++ b/docs/rules/en/Azure.VM.ADE.md
@@ -25,6 +25,11 @@ ADE protects disk decryption keys within Key Vault.
 
 Consider using Azure Disk Encryption (ADE) to protect VM disks from being downloaded and accessed offline.
 
+## NOTE
+
+This rule is applicable to exports of exiting resources.
+This rule will be skipped when validating Azure template files.
+
 ## LINKS
 
 - [Creating and configuring a key vault for Azure Disk Encryption](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disk-encryption-key-vault)

--- a/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VM.Rule.ps1
@@ -168,7 +168,7 @@ Rule 'Azure.VM.DiskSizeAlignment' -Type 'Microsoft.Compute/disks' -Tag @{ releas
 # TODO: Check number of disks
 
 # Synopsis: Use Azure Disk Encryption
-Rule 'Azure.VM.ADE' -Type 'Microsoft.Compute/disks' -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
+Rule 'Azure.VM.ADE' -Type 'Microsoft.Compute/disks' -If { IsExport } -Tag @{ release = 'GA'; ruleSet = '2020_06' } {
     $Assert.HasFieldValue($TargetObject, 'Properties.encryptionSettingsCollection.enabled', $True)
     $Assert.HasFieldValue($TargetObject, 'Properties.encryptionSettingsCollection.encryptionSettings')
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VM.Tests.ps1
@@ -1076,15 +1076,11 @@ Describe 'Azure.VM' {
                 $_.TargetType -eq 'Microsoft.Compute/disks'
             };
 
-            # Fail
-            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -BeIn 'vm-A-disk1', 'vm-A-disk2';
-
-            # Pass
-            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
-            $ruleResult | Should -BeNullOrEmpty;
         }
 
         It 'Azure.VM.PublicKey' {


### PR DESCRIPTION
## PR Summary

- Fixed `Azure.VM.ADE` to limit rule to exports only. #644

Fixes #644 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [ ] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
