### PR TITLE
Bug fixes for #652 #653 #654 #655

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+What's changed since pre-release v1.1.0-B2102010:
+
+- Bug fixes:
+  - Fixed `if` condition values evaluation order. [#652](https://github.com/microsoft/PSRule.Rules.Azure/issues/652)
+  - Fixed handling of `int` parameters with large values. [#653](https://github.com/microsoft/PSRule.Rules.Azure/issues/653)
+  - Fixed handling of expressions split over multiple lines. [#654](https://github.com/microsoft/PSRule.Rules.Azure/issues/654)
+  - Fixed handling of bool parameter values within logical expressions. [#655](https://github.com/microsoft/PSRule.Rules.Azure/issues/655)
+
 ## v1.1.0-B2102010 (pre-release)
 
 What's changed since pre-release v1.1.0-B2102001:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -226,11 +226,13 @@ namespace PSRule.Rules.Azure.Data.Template
     internal sealed class FunctionDescriptor : IFunctionDescriptor
     {
         private readonly ExpressionFn Fn;
+        private readonly bool DelayBinding;
 
-        public FunctionDescriptor(string name, ExpressionFn fn)
+        public FunctionDescriptor(string name, ExpressionFn fn, bool delayBinding = false)
         {
             Name = name;
             Fn = fn;
+            DelayBinding = delayBinding;
         }
 
         public string Name { get; }
@@ -239,7 +241,7 @@ namespace PSRule.Rules.Azure.Data.Template
         {
             var parameters = new object[args.Length];
             for (var i = 0; i < args.Length; i++)
-                parameters[i] = args[i](context);
+                parameters[i] = DelayBinding ? args[i] : args[i](context);
 
             return Fn(context, parameters);
         }

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -35,7 +35,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out value))
                 return true;
 
-            if (TryInt(o, out int ivalue))
+            if (TryLong(o, out long ivalue))
             {
                 value = ivalue.ToString(Thread.CurrentThread.CurrentCulture);
                 return true;
@@ -62,6 +62,45 @@ namespace PSRule.Rules.Azure.Data.Template
         /// <summary>
         /// Try to get an int from the existing object.
         /// </summary>
+        internal static bool TryLong(object o, out long value)
+        {
+            if (o is int i)
+            {
+                value = i;
+                return true;
+            }
+            else if (o is long l)
+            {
+                value = l;
+                return true;
+            }
+            else if (o is JToken token && token.Type == JTokenType.Integer)
+            {
+                value = token.Value<long>();
+                return true;
+            }
+            value = default(long);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get an int from the existing type and allow conversion from string.
+        /// </summary>
+        internal static bool TryConvertLong(object o, out long value)
+        {
+            if (TryLong(o, out value))
+                return true;
+
+            if (TryString(o, out string svalue) && long.TryParse(svalue, out value))
+                return true;
+
+            value = default(long);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get an int from the existing object.
+        /// </summary>
         internal static bool TryInt(object o, out int value)
         {
             if (o is int i)
@@ -74,7 +113,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 value = token.Value<int>();
                 return true;
             }
-            value = 0;
+            value = default(int);
             return false;
         }
 
@@ -89,7 +128,47 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out string svalue) && int.TryParse(svalue, out value))
                 return true;
 
-            value = 0;
+            value = default(int);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get an bool from the existing object.
+        /// </summary>
+        internal static bool TryBool(object o, out bool value)
+        {
+            if (o is bool bvalue)
+            {
+                value = bvalue;
+                return true;
+            }
+            else if (o is JToken token && token.Type == JTokenType.Boolean)
+            {
+                value = token.Value<bool>();
+                return true;
+            }
+            value = default(bool);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get an bool from the existing type and allow conversion from string or int.
+        /// </summary>
+        internal static bool TryConvertBool(object o, out bool value)
+        {
+            if (TryBool(o, out value))
+                return true;
+
+            if (TryLong(o, out long ivalue))
+            {
+                value = ivalue > 0;
+                return true;
+            }
+
+            if (TryString(o, out string svalue) && bool.TryParse(svalue, out value))
+                return true;
+
+            value = default(bool);
             return false;
         }
     }

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
@@ -191,7 +191,8 @@ namespace PSRule.Rules.Azure.Data.Template
         /// </summary>
         public void SkipWhitespace()
         {
-            Skip(Whitespace, max: 0);
+            while (char.IsWhiteSpace(Current))
+                Next();
         }
 
         public bool Skip(char c)
@@ -201,22 +202,6 @@ namespace PSRule.Rules.Azure.Data.Template
 
             Next();
             return true;
-        }
-
-        /// <summary>
-        /// Skip ahead if the current character is expected. Keep skipping when the character is repeated.
-        /// </summary>
-        /// <param name="c">The character to skip.</param>
-        /// <returns>The number of characters that where skipped.</returns>
-        public int Skip(char c, int max)
-        {
-            var skipped = 0;
-            while (Current == c && (max == 0 || skipped < max))
-            {
-                Next();
-                skipped++;
-            }
-            return skipped;
         }
 
         /// <summary>

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -66,7 +66,7 @@ namespace PSRule.Rules.Azure.Data.Template
             new FunctionDescriptor("and", And),
             new FunctionDescriptor("bool", Bool),
             new FunctionDescriptor("false", False),
-            new FunctionDescriptor("if", If),
+            new FunctionDescriptor("if", If, delayBinding: true),
             new FunctionDescriptor("not", Not),
             new FunctionDescriptor("or", Or),
             new FunctionDescriptor("true", True),
@@ -379,10 +379,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) == 0)
                 throw ArgumentsOutOfRange(nameof(Min), args);
 
-            int? result = null;
+            long? result = null;
             for (var i = 0; i < args.Length; i++)
             {
-                if (ExpressionHelpers.TryInt(args[i], out int value))
+                if (ExpressionHelpers.TryLong(args[i], out long value))
                 {
                     result = !result.HasValue || value < result ? value : result;
                 }
@@ -391,7 +391,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 {
                     for (var j = 0; j < array.Count; j++)
                     {
-                        if (ExpressionHelpers.TryInt(array[j], out value))
+                        if (ExpressionHelpers.TryLong(array[j], out value))
                         {
                             result = !result.HasValue || value < result ? value : result;
                         }
@@ -410,10 +410,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) == 0)
                 throw ArgumentsOutOfRange(nameof(Max), args);
 
-            int? result = null;
+            long? result = null;
             for (var i = 0; i < args.Length; i++)
             {
-                if (ExpressionHelpers.TryInt(args[i], out int value))
+                if (ExpressionHelpers.TryLong(args[i], out long value))
                 {
                     result = !result.HasValue || value > result ? value : result;
                 }
@@ -422,7 +422,7 @@ namespace PSRule.Rules.Azure.Data.Template
                 {
                     for (var j = 0; j < array.Count; j++)
                     {
-                        if (ExpressionHelpers.TryInt(array[j], out value))
+                        if (ExpressionHelpers.TryLong(array[j], out value))
                         {
                             result = !result.HasValue || value > result ? value : result;
                         }
@@ -441,13 +441,13 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Range), args);
 
-            if (!ExpressionHelpers.TryInt(args[0], out int startIndex))
+            if (!ExpressionHelpers.TryLong(args[0], out long startIndex))
                 throw ArgumentInvalidInteger(nameof(Range), nameof(startIndex));
 
-            if (!ExpressionHelpers.TryInt(args[1], out int count))
+            if (!ExpressionHelpers.TryLong(args[1], out long count))
                 throw ArgumentInvalidInteger(nameof(Range), nameof(count));
 
-            var result = new int[count];
+            var result = new long[count];
             for (var i = 0; i < count; i++)
                 result[i] = startIndex++;
 
@@ -900,10 +900,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Add), args);
 
-            if (!ExpressionHelpers.TryConvertInt(args[0], out int operand1))
+            if (!ExpressionHelpers.TryConvertLong(args[0], out long operand1))
                 throw ArgumentInvalidInteger(nameof(Add), "operand1");
 
-            if (!ExpressionHelpers.TryConvertInt(args[1], out int operand2))
+            if (!ExpressionHelpers.TryConvertLong(args[1], out long operand2))
                 throw ArgumentInvalidInteger(nameof(Add), "operand2");
 
             return operand1 + operand2;
@@ -927,10 +927,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Div), args);
 
-            if (!ExpressionHelpers.TryConvertInt(args[0], out int operand1))
+            if (!ExpressionHelpers.TryConvertLong(args[0], out long operand1))
                 throw ArgumentInvalidInteger(nameof(Div), "operand1");
 
-            if (!ExpressionHelpers.TryConvertInt(args[1], out int operand2))
+            if (!ExpressionHelpers.TryConvertLong(args[1], out long operand2))
                 throw ArgumentInvalidInteger(nameof(Div), "operand2");
 
             if (operand2 == 0)
@@ -944,7 +944,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(Float), args);
 
-            if (ExpressionHelpers.TryConvertInt(args[0], out int ivalue))
+            if (ExpressionHelpers.TryConvertLong(args[0], out long ivalue))
                 return (float)ivalue;
             else if (ExpressionHelpers.TryString(args[0], out string svalue))
                 return float.Parse(svalue, new CultureInfo("en-us"));
@@ -957,7 +957,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 1)
                 throw ArgumentsOutOfRange(nameof(Int), args);
 
-            if (ExpressionHelpers.TryConvertInt(args[0], out int value))
+            if (ExpressionHelpers.TryConvertLong(args[0], out long value))
                 return value;
 
             throw ArgumentInvalidInteger(nameof(Int), "valueToConvert");
@@ -968,10 +968,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Mod), args);
 
-            if (!ExpressionHelpers.TryConvertInt(args[0], out int operand1))
+            if (!ExpressionHelpers.TryConvertLong(args[0], out long operand1))
                 throw ArgumentInvalidInteger(nameof(Mod), "operand1");
 
-            if (!ExpressionHelpers.TryConvertInt(args[1], out int operand2))
+            if (!ExpressionHelpers.TryConvertLong(args[1], out long operand2))
                 throw ArgumentInvalidInteger(nameof(Mod), "operand2");
 
             if (operand2 == 0)
@@ -985,10 +985,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Mul), args);
 
-            if (!ExpressionHelpers.TryConvertInt(args[0], out int operand1))
+            if (!ExpressionHelpers.TryConvertLong(args[0], out long operand1))
                 throw ArgumentInvalidInteger(nameof(Mul), "operand1");
 
-            if (!ExpressionHelpers.TryConvertInt(args[1], out int operand2))
+            if (!ExpressionHelpers.TryConvertLong(args[1], out long operand2))
                 throw ArgumentInvalidInteger(nameof(Mul), "operand2");
 
             return operand1 * operand2;
@@ -999,10 +999,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (CountArgs(args) != 2)
                 throw ArgumentsOutOfRange(nameof(Sub), args);
 
-            if (!ExpressionHelpers.TryConvertInt(args[0], out int operand1))
+            if (!ExpressionHelpers.TryConvertLong(args[0], out long operand1))
                 throw ArgumentInvalidInteger(nameof(Sub), "operand1");
 
-            if (!ExpressionHelpers.TryConvertInt(args[1], out int operand2))
+            if (!ExpressionHelpers.TryConvertLong(args[1], out long operand2))
                 throw ArgumentInvalidInteger(nameof(Sub), "operand2");
 
             return operand1 - operand2;
@@ -1031,13 +1031,13 @@ namespace PSRule.Rules.Azure.Data.Template
                 return false;
 
             // String and int
-            if (args[0] is string s1 && args[1] is string s2)
+            if (ExpressionHelpers.TryString(args[0], out string s1) && ExpressionHelpers.TryString(args[1], out string s2))
                 return s1 == s2;
-            else if (args[0] is string || args[1] is string)
+            else if (ExpressionHelpers.TryString(args[0], out _) || ExpressionHelpers.TryString(args[1], out _))
                 return false;
-            else if (args[0] is int i1 && args[1] is int i2)
+            else if (ExpressionHelpers.TryLong(args[0], out long i1) && ExpressionHelpers.TryLong(args[1], out long i2))
                 return i1 == i2;
-            else if (args[0] is int || args[1] is int)
+            else if (ExpressionHelpers.TryLong(args[0], out _) || ExpressionHelpers.TryLong(args[1], out _))
                 return false;
 
             // Objects
@@ -1141,11 +1141,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length < 2)
                 throw ArgumentsOutOfRange(nameof(And), args);
 
-            var bools = new bool[args.Length];
-            args.CopyTo(bools, 0);
-            for (var i = 0; i < bools.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
-                if (!bools[i])
+                if (!ExpressionHelpers.TryBool(args[i], out bool bvalue) || !bvalue)
                     return false;
             }
             return true;
@@ -1159,12 +1157,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length != 1)
                 throw ArgumentsOutOfRange(nameof(Bool), args);
 
-            if (args[0] is string svalue)
-                return bool.Parse(svalue);
-            else if (args[0] is int ivalue)
-                return ivalue > 0;
+            if (ExpressionHelpers.TryConvertBool(args[0], out bool value))
+                return value;
 
-            return false;
+            throw ArgumentFormatInvalid(nameof(Bool));
         }
 
         /// <summary>
@@ -1186,7 +1182,11 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length != 3)
                 throw ArgumentsOutOfRange(nameof(If), args);
 
-            return args[0] is bool condition && condition == true ? args[1] : args[2];
+            var expression = GetExpression(context, args[0]);
+            if (ExpressionHelpers.TryBool(expression, out bool condition))
+                return condition ? GetExpression(context, args[1]) : GetExpression(context, args[2]);
+
+            throw ArgumentFormatInvalid(nameof(If));
         }
 
         /// <summary>
@@ -1197,7 +1197,10 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length != 1)
                 throw ArgumentsOutOfRange(nameof(Not), args);
 
-            return !(bool)args[0];
+            if (!ExpressionHelpers.TryBool(args[0], out bool value))
+                throw ArgumentInvalidBoolean(nameof(Not), "arg1");
+
+            return !value;
         }
 
         /// <summary>
@@ -1208,11 +1211,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length < 2)
                 throw ArgumentsOutOfRange(nameof(Or), args);
 
-            var bools = new bool[args.Length];
-            args.CopyTo(bools, 0);
-            for (var i = 0; i < bools.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
-                if (bools[i])
+                if (ExpressionHelpers.TryBool(args[i], out bool value) && value)
                     return true;
             }
             return false;
@@ -1662,6 +1663,11 @@ namespace PSRule.Rules.Azure.Data.Template
             return resourceType[resourceType.Length - 1] == '/' ? resourceType = resourceType.Substring(0, resourceType.Length - 1) : resourceType;
         }
 
+        private static object GetExpression(TemplateContext context, object o)
+        {
+            return o is ExpressionFnOuter fn ? fn(context) : o;
+        }
+
         #endregion Helper functions
 
         #region Exceptions
@@ -1688,6 +1694,14 @@ namespace PSRule.Rules.Azure.Data.Template
             return new ExpressionArgumentException(
                 expression,
                 string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentInvalidInteger, operand, expression)
+            );
+        }
+
+        private static ExpressionArgumentException ArgumentInvalidBoolean(string expression, string operand)
+        {
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentInvalidBoolean, operand, expression)
             );
         }
 

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -384,7 +384,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (type == ParameterType.Bool)
                 context.Parameter(parameterName, new LazyParameter<bool>(defaultValue));
             else if (type == ParameterType.Int)
-                context.Parameter(parameterName, new LazyParameter<int>(defaultValue));
+                context.Parameter(parameterName, new LazyParameter<long>(defaultValue));
             else if (type == ParameterType.String)
                 context.Parameter(parameterName, new LazyParameter<string>(defaultValue));
             else if (type == ParameterType.Array)
@@ -424,14 +424,14 @@ namespace PSRule.Rules.Azure.Data.Template
 
         private void ResourceOuter(TemplateContext context, JObject resource)
         {
-            var condition = !resource.ContainsKey("condition") || ExpandProperty<bool>(context, resource, "condition");
-            if (!condition)
-                return;
-
             var copyIndex = GetResourceIterator(context, resource);
             while (copyIndex.Next())
             {
                 var instance = copyIndex.Input.DeepClone() as JObject;
+                var condition = !resource.ContainsKey("condition") || ExpandProperty<bool>(context, resource, "condition");
+                if (!condition)
+                    continue;
+
                 Resource(context, instance);
             }
             if (copyIndex.IsCopy())

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -70,6 +70,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid boolean..
+        /// </summary>
+        internal static string ArgumentInvalidBoolean {
+            get {
+                return ResourceManager.GetString("ArgumentInvalidBoolean", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid integer..
         /// </summary>
         internal static string ArgumentInvalidInteger {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -120,6 +120,9 @@
   <data name="ArgumentFormatInvalid" xml:space="preserve">
     <value>The arguments for '{0}' are not in the expected format or type.</value>
   </data>
+  <data name="ArgumentInvalidBoolean" xml:space="preserve">
+    <value>The argument '{0}' for '{1}' is not a valid boolean.</value>
+  </data>
   <data name="ArgumentInvalidInteger" xml:space="preserve">
     <value>The argument '{0}' for '{1}' is not a valid integer.</value>
   </data>

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
@@ -148,5 +148,18 @@ namespace PSRule.Rules.Azure
             Assert.Equal(ExpressionTokenType.Property, actual[5].Type); // includedEventTypes
             Assert.Equal("includedEventTypes", actual[5].Content);
         }
+
+        [Fact]
+        public void ParseExpression8()
+        {
+            var expression = "[\r\nparameters(\r\n                 'vnetName'\r\n)\r\n]";
+            var actual = ExpressionParser.Parse(expression).ToArray();
+            Assert.Equal(ExpressionTokenType.Element, actual[0].Type); // parameters
+            Assert.Equal("parameters", actual[0].Content);
+            Assert.Equal(ExpressionTokenType.GroupStart, actual[1].Type);
+            Assert.Equal(ExpressionTokenType.String, actual[2].Type); // 'vnetName'
+            Assert.Equal("vnetName", actual[2].Content);
+            Assert.Equal(ExpressionTokenType.GroupEnd, actual[3].Type);
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -276,17 +276,17 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Max(context, new object[] { 6, 4, 8, 1, 2 });
-            var actual2 = (int)Functions.Max(context, new object[] { 1, 1, 1 });
-            var actual3 = (int)Functions.Max(context, new object[] { 1 });
+            var actual1 = (long)Functions.Max(context, new object[] { 6, 4, 8, 1, 2 });
+            var actual2 = (long)Functions.Max(context, new object[] { 1, 1, 1 });
+            var actual3 = (long)Functions.Max(context, new object[] { 1 });
             Assert.Equal(8, actual1);
             Assert.Equal(1, actual2);
             Assert.Equal(1, actual3);
 
             // Array
-            var actual4 = (int)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4, 8, 1, 2 }) });
-            var actual5 = (int)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4 }), 8 });
-            var actual6 = (int)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4 }), new JArray(new int[] { 8 }) });
+            var actual4 = (long)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4, 8, 1, 2 }) });
+            var actual5 = (long)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4 }), 8 });
+            var actual6 = (long)Functions.Max(context, new object[] { new JArray(new int[] { 6, 4 }), new JArray(new int[] { 8 }) });
             Assert.Equal(8, actual4);
             Assert.Equal(8, actual5);
             Assert.Equal(8, actual6);
@@ -304,17 +304,17 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Min(context, new object[] { 6, 4, 8, 1, 2 });
-            var actual2 = (int)Functions.Min(context, new object[] { 1, 1, 1 });
-            var actual3 = (int)Functions.Min(context, new object[] { 1 });
+            var actual1 = (long)Functions.Min(context, new object[] { 6, 4, 8, 1, 2 });
+            var actual2 = (long)Functions.Min(context, new object[] { 1, 1, 1 });
+            var actual3 = (long)Functions.Min(context, new object[] { 1 });
             Assert.Equal(1, actual1);
             Assert.Equal(1, actual2);
             Assert.Equal(1, actual3);
 
             // Array
-            var actual4 = (int)Functions.Min(context, new object[] { new JArray(new int[] { 6, 4, 8, 1, 2 }) });
-            var actual5 = (int)Functions.Min(context, new object[] { new JArray(new int[] { 6, 4 }), 8 });
-            var actual6 = (int)Functions.Min(context, new object[] { new JArray(new int[] { 6, 4 }), new JArray(new int[] { 8 }) });
+            var actual4 = (long)Functions.Min(context, new object[] { new JArray(new int[] { 6, 4, 8, 1, 2 }) });
+            var actual5 = (long)Functions.Min(context, new object[] { new JArray(new long[] { 6, 4 }), 8 });
+            var actual6 = (long)Functions.Min(context, new object[] { new JArray(new int[] { 6, 4 }), new JArray(new int[] { 8 }) });
             Assert.Equal(1, actual4);
             Assert.Equal(4, actual5);
             Assert.Equal(4, actual6);
@@ -671,7 +671,7 @@ namespace PSRule.Rules.Azure
             // int
             var actual1 = (bool)Functions.Equals(context, new object[] { 1, 2 });
             var actual2 = (bool)Functions.Equals(context, new object[] { 2, 1 });
-            var actual3 = (bool)Functions.Equals(context, new object[] { 1, 1 });
+            var actual3 = (bool)Functions.Equals(context, new object[] { new JValue(1), 1 });
             Assert.False(actual1);
             Assert.False(actual2);
             Assert.True(actual3);
@@ -842,9 +842,12 @@ namespace PSRule.Rules.Azure
             var actual1 = (bool)Functions.And(context, new object[] { true, true, true });
             var actual2 = (bool)Functions.And(context, new object[] { true, true, false });
             var actual3 = (bool)Functions.And(context, new object[] { false, false });
+            var actual4 = (bool)Functions.And(context, new object[] { new JValue(true), true });
+
             Assert.True(actual1);
             Assert.False(actual2);
             Assert.False(actual3);
+            Assert.True(actual4);
         }
 
         [Fact]
@@ -855,8 +858,14 @@ namespace PSRule.Rules.Azure
 
             var actual1 = (bool)Functions.Bool(context, new object[] { "true" });
             var actual2 = (bool)Functions.Bool(context, new object[] { "false" });
+            var actual3 = (bool)Functions.Bool(context, new object[] { 1 });
+            var actual4 = (bool)Functions.Bool(context, new object[] { 0 });
+            var actual5 = (bool)Functions.Bool(context, new object[] { new JValue(1) });
             Assert.True(actual1);
             Assert.False(actual2);
+            Assert.True(actual3);
+            Assert.False(actual4);
+            Assert.True(actual5);
         }
 
         [Fact]
@@ -881,8 +890,10 @@ namespace PSRule.Rules.Azure
 
             var actual1 = (bool)Functions.If(context, new object[] { true, true, false });
             var actual2 = (bool)Functions.If(context, new object[] { false, true, false });
+            var actual3 = (bool)Functions.If(context, new object[] { new JValue(true), true, false });
             Assert.True(actual1);
             Assert.False(actual2);
+            Assert.True(actual3);
         }
 
         [Fact]
@@ -893,8 +904,10 @@ namespace PSRule.Rules.Azure
 
             var actual1 = (bool)Functions.Not(context, new object[] { true });
             var actual2 = (bool)Functions.Not(context, new object[] { false });
+            var actual3 = (bool)Functions.Not(context, new object[] { new JValue(false) });
             Assert.False(actual1);
             Assert.True(actual2);
+            Assert.True(actual3);
         }
 
         [Fact]
@@ -906,9 +919,11 @@ namespace PSRule.Rules.Azure
             var actual1 = (bool)Functions.Or(context, new object[] { true, true, true });
             var actual2 = (bool)Functions.Or(context, new object[] { true, false });
             var actual3 = (bool)Functions.Or(context, new object[] { false, false, false });
+            var actual4 = (bool)Functions.Or(context, new object[] { new JValue(true), true });
             Assert.True(actual1);
             Assert.True(actual2);
             Assert.False(actual3);
+            Assert.True(actual4);
         }
 
         [Fact]
@@ -936,7 +951,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Add(context, new object[] { 5, 3 });
+            var actual1 = (long)Functions.Add(context, new object[] { 5, 3 });
             Assert.Equal(8, actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Add(context, null));
@@ -951,7 +966,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Div(context, new object[] { 8, 3 });
+            var actual1 = (long)Functions.Div(context, new object[] { 8, 3 });
             Assert.Equal(2, actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Div(context, null));
@@ -987,11 +1002,11 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Int(context, new object[] { 4 });
+            var actual1 = (long)Functions.Int(context, new object[] { 4 });
             Assert.Equal(4, actual1);
 
             // String
-            var actual2 = (int)Functions.Int(context, new object[] { "4" });
+            var actual2 = (long)Functions.Int(context, new object[] { "4" });
             Assert.Equal(4, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Int(context, null));
@@ -1006,7 +1021,7 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Mod(context, new object[] { 7, "3" });
+            var actual1 = (long)Functions.Mod(context, new object[] { 7, "3" });
             Assert.Equal(1, actual1);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Mod(context, null));
@@ -1023,8 +1038,10 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Mul(context, new object[] { 5, "3" });
+            var actual1 = (long)Functions.Mul(context, new object[] { 5, "3" });
+            var actual2 = (long)Functions.Mul(context, new object[] { new JValue(5), (long)3 });
             Assert.Equal(15, actual1);
+            Assert.Equal(15, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Mul(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Mul(context, new object[] { 5 }));
@@ -1038,8 +1055,10 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (int)Functions.Sub(context, new object[] { 7, 3 });
+            var actual1 = (long)Functions.Sub(context, new object[] { 7, 3 });
+            var actual2 = (long)Functions.Sub(context, new object[] { new JValue(7), 3 });
             Assert.Equal(4, actual1);
+            Assert.Equal(4, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Sub(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Sub(context, new object[] { 5 }));


### PR DESCRIPTION
## PR Summary

- Fixed `if` condition values evaluation order. #652
- Fixed handling of `int` parameters with large values. #653
- Fixed handling of expressions split over multiple lines. #654
- Fixed handling of bool parameter values within logical expressions. #655

Fixes #652 
Fixes #653 
Fixes #654 
Fixes #655

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
