### PR TITLE
Fixes template expansion issues #664 #666 #667

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,10 @@ What's changed since pre-release v1.1.0-B2102023:
 - General improvements:
   - Added support for matching template by name. [#661](https://github.com/microsoft/PSRule.Rules.Azure/issues/661)
     - `Get-AzRuleTemplateLink` discovers `<templateName>.json` from `<templateName>.parameters.json`.
+- Bug fixes:
+  - Fixed copy loop value does not fall within the expected range. [#664](https://github.com/microsoft/PSRule.Rules.Azure/issues/664)
+  - Fixed template comparison functions handling of large integer values. [#666](https://github.com/microsoft/PSRule.Rules.Azure/issues/666)
+  - Fixed handling of `createArray` function with no arguments. [#667](https://github.com/microsoft/PSRule.Rules.Azure/issues/667)
 
 ## v1.1.0-B2102023 (pre-release)
 

--- a/docs/scenarios/deployment-objects/export.template.json
+++ b/docs/scenarios/deployment-objects/export.template.json
@@ -13,6 +13,10 @@
         "resourceGroup": {
             "type": "object",
             "value": "[resourceGroup()]"
+        },
+        "deployment": {
+            "type": "object",
+            "value": "[deployment()]"
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
+++ b/src/PSRule.Rules.Azure/Common/JsonExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace PSRule.Rules.Azure
+{
+    internal sealed class TemplateTokenAnnotation : IJsonLineInfo
+    {
+        private bool _HasLineInfo;
+
+        public TemplateTokenAnnotation()
+        {
+
+        }
+
+        public TemplateTokenAnnotation(int lineNumber, int linePosition)
+        {
+            SetLineInfo(lineNumber, linePosition);
+        }
+
+        public int LineNumber { get; private set; }
+
+        public int LinePosition { get; private set; }
+
+        public bool HasLineInfo()
+        {
+            return _HasLineInfo;
+        }
+        internal void SetLineInfo(int lineNumber, int linePosition)
+        {
+            LineNumber = lineNumber;
+            LinePosition = linePosition;
+            _HasLineInfo = true;
+        }
+    }
+
+    internal static class JsonExtensions
+    {
+        internal static IJsonLineInfo TryLineInfo(this JToken token)
+        {
+            if (token == null)
+                return null;
+
+            var annotation = token.Annotation<TemplateTokenAnnotation>();
+            if (annotation != null)
+                return annotation;
+
+            return token;
+        }
+
+        internal static JToken CloneTemplateJToken(this JToken token)
+        {
+            if (token == null)
+                return null;
+
+            var annotation = token.Annotation<TemplateTokenAnnotation>();
+            if (annotation == null && token is IJsonLineInfo lineInfo && lineInfo.HasLineInfo())
+                annotation = new TemplateTokenAnnotation(lineInfo.LineNumber, lineInfo.LinePosition);
+
+            var clone = token.DeepClone();
+            if (annotation != null)
+                clone.AddAnnotation(annotation);
+
+            return clone;
+        }
+
+        internal static void CopyTemplateAnnotationFrom(this JToken token, JToken source)
+        {
+            if (token == null || source == null)
+                return;
+
+            var annotation = source.Annotation<TemplateTokenAnnotation>();
+            if (annotation != null)
+                token.AddAnnotation(annotation);
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/Exceptions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Exceptions.cs
@@ -230,6 +230,44 @@ namespace PSRule.Rules.Azure.Data.Template
     }
 
     [Serializable]
+    public sealed class ExpressionEvaluationException : TemplateException
+    {
+        public ExpressionEvaluationException()
+        {
+        }
+
+        public ExpressionEvaluationException(string message)
+            : base(message) { }
+
+        public ExpressionEvaluationException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        internal ExpressionEvaluationException(string expression, string message)
+            : base(message)
+        {
+            Expression = expression;
+        }
+
+        internal ExpressionEvaluationException(string expression, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Expression = expression;
+        }
+
+        private ExpressionEvaluationException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        public string Expression { get; }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+    }
+
+    [Serializable]
     public sealed class ExpressionArgumentException : ExpressionException
     {
         public ExpressionArgumentException()

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -154,6 +154,9 @@ namespace PSRule.Rules.Azure.Data.Template
         private static object Property(TemplateContext context, ExpressionFnOuter inner, string propertyName)
         {
             var result = inner(context);
+            if (result == null)
+                throw new ExpressionReferenceException(propertyName, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.PropertyNotFound, propertyName));
+
             if (result is JObject jObject)
             {
                 var property = jObject.Property(propertyName, StringComparison.OrdinalIgnoreCase);

--- a/src/PSRule.Rules.Azure/Data/Template/TokenStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TokenStream.cs
@@ -59,7 +59,7 @@ namespace PSRule.Rules.Azure.Data.Template
     internal sealed class ExpressionToken
     {
         internal readonly ExpressionTokenType Type;
-        internal readonly int Value;
+        internal readonly long Value;
         internal readonly string Content;
 
         internal ExpressionToken(ExpressionTokenType type, string content)
@@ -68,7 +68,7 @@ namespace PSRule.Rules.Azure.Data.Template
             Content = content;
         }
 
-        internal ExpressionToken(int value)
+        internal ExpressionToken(long value)
         {
             Type = ExpressionTokenType.Numeric;
             Value = value;
@@ -85,7 +85,7 @@ namespace PSRule.Rules.Azure.Data.Template
             stream.Add(new ExpressionToken(ExpressionTokenType.Element, functionName));
         }
 
-        internal static void Numeric(this TokenStream stream, int value)
+        internal static void Numeric(this TokenStream stream, long value)
         {
             stream.Add(new ExpressionToken(value));
         }

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
@@ -87,7 +87,7 @@ namespace PSRule.Rules.Azure.Pipeline
 
         protected PipelineContext PrepareContext()
         {
-            return new PipelineContext(Option);
+            return new PipelineContext(Option, PrepareWriter());
         }
 
         protected virtual PipelineWriter PrepareWriter()
@@ -107,16 +107,14 @@ namespace PSRule.Rules.Azure.Pipeline
     internal abstract class PipelineBase : IDisposable, IPipeline
     {
         protected readonly PipelineContext Context;
-        protected readonly PipelineWriter Writer;
 
         // Track whether Dispose has been called.
         private bool _Disposed = false;
         
 
-        protected PipelineBase(PipelineContext context, PipelineWriter writer)
+        protected PipelineBase(PipelineContext context)
         {
             Context = context;
-            Writer = writer;
         }
 
         #region IPipeline
@@ -133,7 +131,7 @@ namespace PSRule.Rules.Azure.Pipeline
 
         public virtual void End()
         {
-            Writer.End();
+            Context.Writer.End();
         }
 
         #endregion IPipeline

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineContext.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineContext.cs
@@ -7,11 +7,14 @@ namespace PSRule.Rules.Azure.Pipeline
 {
     internal sealed class PipelineContext
     {
-        internal readonly PSRuleOption Option;
-
-        public PipelineContext(PSRuleOption option)
+        internal PipelineContext(PSRuleOption option, PipelineWriter writer)
         {
             Option = option;
+            Writer = writer;
         }
+
+        public PSRuleOption Option { get; }
+
+        public PipelineWriter Writer { get; }
     }
 }

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineWriter.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineWriter.cs
@@ -142,6 +142,16 @@ namespace PSRule.Rules.Azure.Pipeline
             _Writer.WriteDebug(debugRecord);
         }
 
+        public void WriteDebug(string format, params object[] args)
+        {
+            if (_Writer == null || string.IsNullOrEmpty(format))
+                return;
+
+            var message = args == null || args.Length == 0 ? format : string.Format(format, args);
+            var debugRecord = new DebugRecord(message);
+            _Writer.WriteDebug(debugRecord);
+        }
+
         public virtual bool ShouldWriteDebug()
         {
             return _Writer != null && _Writer.ShouldWriteDebug();

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -115,6 +115,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occured evaluating expression &apos;{0}&apos; line {1}. {2}.
+        /// </summary>
+        internal static string ExpressionEvaluateError {
+            get {
+                return ResourceManager.GetString("ExpressionEvaluateError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to parse expression. The expression may not be valid. Expression: &quot;{0}&quot;.
         /// </summary>
         internal static string ExpressionInvalid {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -135,6 +135,9 @@
   <data name="ArgumentsOutOfRange" xml:space="preserve">
     <value>The number of arguments '{1}' is not within the allowed range for '{0}'.</value>
   </data>
+  <data name="ExpressionEvaluateError" xml:space="preserve">
+    <value>An error occured evaluating expression '{0}' line {1}. {2}</value>
+  </data>
   <data name="ExpressionInvalid" xml:space="preserve">
     <value>Failed to parse expression. The expression may not be valid. Expression: "{0}"</value>
     <comment>Occurs when an expression fails to be parsed.</comment>

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -106,14 +106,15 @@ namespace PSRule.Rules.Azure
             var actual1 = Functions.CreateArray(context, new object[] { 1, 2, 3 }) as JArray;
             var actual2 = Functions.CreateArray(context, new object[] { "efgh" }) as JArray;
             var actual3 = Functions.CreateArray(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }") }) as JArray;
+            var actual4 = Functions.CreateArray(context, null) as JArray;
+            var actual5 = Functions.CreateArray(context, new object[] { }) as JArray;
             Assert.Equal(3, actual1.Count);
             Assert.Equal(1, actual1[0]);
             Assert.Equal("efgh", actual2[0]);
             Assert.Equal("b", actual3[0]["a"]);
             Assert.Equal("h", actual3[1]["g"]);
-
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateArray(context, null));
-            Assert.Throws<ExpressionArgumentException>(() => Functions.CreateArray(context, new object[] { }));
+            Assert.Empty(actual4);
+            Assert.Empty(actual5);
         }
 
         [Fact]
@@ -255,15 +256,15 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Length arrays
-            var actual1 = (int)Functions.Length(context, new object[] { new string[] { "one", "two", "three" } });
+            var actual1 = (long)Functions.Length(context, new object[] { new string[] { "one", "two", "three" } });
             Assert.Equal(3, actual1);
 
             // Length strings
-            var actual2 = (int)Functions.Length(context, new object[] { "One Two Three" });
+            var actual2 = (long)Functions.Length(context, new object[] { "One Two Three" });
             Assert.Equal(13, actual2);
 
             // Length objects
-            var actual3 = (int)Functions.Length(context, new object[] { new TestLengthObject() });
+            var actual3 = (long)Functions.Length(context, new object[] { new TestLengthObject() });
             Assert.Equal(4, actual3);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Length(context, null));
@@ -710,7 +711,7 @@ namespace PSRule.Rules.Azure
             // int
             var actual1 = (bool)Functions.Greater(context, new object[] { 1, 2 });
             var actual2 = (bool)Functions.Greater(context, new object[] { 2, 1 });
-            var actual3 = (bool)Functions.Greater(context, new object[] { 1, 1 });
+            var actual3 = (bool)Functions.Greater(context, new object[] { new JValue(1), 1 });
             Assert.False(actual1);
             Assert.True(actual2);
             Assert.False(actual3);
@@ -718,7 +719,7 @@ namespace PSRule.Rules.Azure
             // string
             var actual4 = (bool)Functions.Greater(context, new object[] { "Test1", "Test2" });
             var actual5 = (bool)Functions.Greater(context, new object[] { "Test2", "Test1" });
-            var actual6 = (bool)Functions.Greater(context, new object[] { "Test1", "Test1" });
+            var actual6 = (bool)Functions.Greater(context, new object[] { new JValue("Test1"), "Test1" });
             Assert.False(actual4);
             Assert.True(actual5);
             Assert.False(actual6);
@@ -733,7 +734,7 @@ namespace PSRule.Rules.Azure
             // int
             var actual1 = (bool)Functions.GreaterOrEquals(context, new object[] { 1, 2 });
             var actual2 = (bool)Functions.GreaterOrEquals(context, new object[] { 2, 1 });
-            var actual3 = (bool)Functions.GreaterOrEquals(context, new object[] { 1, 1 });
+            var actual3 = (bool)Functions.GreaterOrEquals(context, new object[] { new JValue(1), 1 });
             Assert.False(actual1);
             Assert.True(actual2);
             Assert.True(actual3);
@@ -741,7 +742,7 @@ namespace PSRule.Rules.Azure
             // string
             var actual4 = (bool)Functions.GreaterOrEquals(context, new object[] { "Test1", "Test2" });
             var actual5 = (bool)Functions.GreaterOrEquals(context, new object[] { "Test2", "Test1" });
-            var actual6 = (bool)Functions.GreaterOrEquals(context, new object[] { "Test1", "Test1" });
+            var actual6 = (bool)Functions.GreaterOrEquals(context, new object[] { new JValue("Test1"), "Test1" });
             Assert.False(actual4);
             Assert.True(actual5);
             Assert.True(actual6);
@@ -756,7 +757,7 @@ namespace PSRule.Rules.Azure
             // int
             var actual1 = (bool)Functions.Less(context, new object[] { 1, 2 });
             var actual2 = (bool)Functions.Less(context, new object[] { 2, 1 });
-            var actual3 = (bool)Functions.Less(context, new object[] { 1, 1 });
+            var actual3 = (bool)Functions.Less(context, new object[] { new JValue(1), 1 });
             Assert.True(actual1);
             Assert.False(actual2);
             Assert.False(actual3);
@@ -764,7 +765,7 @@ namespace PSRule.Rules.Azure
             // string
             var actual4 = (bool)Functions.Less(context, new object[] { "Test1", "Test2" });
             var actual5 = (bool)Functions.Less(context, new object[] { "Test2", "Test1" });
-            var actual6 = (bool)Functions.Less(context, new object[] { "Test1", "Test1" });
+            var actual6 = (bool)Functions.Less(context, new object[] { new JValue("Test1"), "Test1" });
             Assert.True(actual4);
             Assert.False(actual5);
             Assert.False(actual6);
@@ -779,7 +780,7 @@ namespace PSRule.Rules.Azure
             // int
             var actual1 = (bool)Functions.LessOrEquals(context, new object[] { 1, 2 });
             var actual2 = (bool)Functions.LessOrEquals(context, new object[] { 2, 1 });
-            var actual3 = (bool)Functions.LessOrEquals(context, new object[] { 1, 1 });
+            var actual3 = (bool)Functions.LessOrEquals(context, new object[] { new JValue(1), 1 });
             Assert.True(actual1);
             Assert.False(actual2);
             Assert.True(actual3);
@@ -787,7 +788,7 @@ namespace PSRule.Rules.Azure
             // string
             var actual4 = (bool)Functions.LessOrEquals(context, new object[] { "Test1", "Test2" });
             var actual5 = (bool)Functions.LessOrEquals(context, new object[] { "Test2", "Test1" });
-            var actual6 = (bool)Functions.LessOrEquals(context, new object[] { "Test1", "Test1" });
+            var actual6 = (bool)Functions.LessOrEquals(context, new object[] { new JValue("Test1"), "Test1" });
             Assert.True(actual4);
             Assert.False(actual5);
             Assert.True(actual6);
@@ -955,8 +956,10 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (long)Functions.Add(context, new object[] { 5, 3 });
+            var actual1 = (long)Functions.Add(context, new object[] { 5, (long)3 });
+            var actual2 = (long)Functions.Add(context, new object[] { new JValue(5), 3 });
             Assert.Equal(8, actual1);
+            Assert.Equal(8, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Add(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Add(context, new object[] { 5 }));
@@ -970,8 +973,10 @@ namespace PSRule.Rules.Azure
             var context = GetContext();
 
             // Integer
-            var actual1 = (long)Functions.Div(context, new object[] { 8, 3 });
+            var actual1 = (long)Functions.Div(context, new object[] { 8, (long)3 });
+            var actual2 = (long)Functions.Div(context, new object[] { new JValue(8), 3 });
             Assert.Equal(2, actual1);
+            Assert.Equal(2, actual2);
 
             Assert.Throws<ExpressionArgumentException>(() => Functions.Div(context, null));
             Assert.Throws<ExpressionArgumentException>(() => Functions.Div(context, new object[] { 5 }));
@@ -1200,9 +1205,9 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
-            var actual1 = (int)Functions.IndexOf(context, new object[] { "test", "t" });
-            var actual2 = (int)Functions.IndexOf(context, new object[] { "abcdef", "CD" });
-            var actual3 = (int)Functions.IndexOf(context, new object[] { "abcdef", "z" });
+            var actual1 = (long)Functions.IndexOf(context, new object[] { "test", "t" });
+            var actual2 = (long)Functions.IndexOf(context, new object[] { "abcdef", "CD" });
+            var actual3 = (long)Functions.IndexOf(context, new object[] { "abcdef", "z" });
             Assert.Equal(0, actual1);
             Assert.Equal(2, actual2);
             Assert.Equal(-1, actual3);
@@ -1218,9 +1223,9 @@ namespace PSRule.Rules.Azure
         {
             var context = GetContext();
 
-            var actual1 = (int)Functions.LastIndexOf(context, new object[] { "test", "t" });
-            var actual2 = (int)Functions.LastIndexOf(context, new object[] { "abcdef", "AB" });
-            var actual3 = (int)Functions.LastIndexOf(context, new object[] { "abcdef", "z" });
+            var actual1 = (long)Functions.LastIndexOf(context, new object[] { "test", "t" });
+            var actual2 = (long)Functions.LastIndexOf(context, new object[] { "abcdef", "AB" });
+            var actual3 = (long)Functions.LastIndexOf(context, new object[] { "abcdef", "z" });
             Assert.Equal(3, actual1);
             Assert.Equal(0, actual2);
             Assert.Equal(-1, actual3);

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -55,6 +55,9 @@
     <None Update="Resources.Template4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Template.Parsing.1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.1.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.1.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "propertyArray": {
+            "type": "array",
+            "defaultValue": [
+                {
+                    "name": "item1"
+                },
+                {
+                    "name": "item2"
+                },
+                {
+                    "name": "item3"
+                }
+            ],
+            "metadata": {
+                "description": "Test property copy loop."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Namespace/resourceType",
+            "apiVersion": "2020-05-01",
+            "name": "copyLoopProperty",
+            "location": "region",
+            "properties": {
+                "copy": [
+                    {
+                        "name": "loop1",
+                        "count": "[length(parameters('propertyArray'))]",
+                        "input": {
+                            "key1": "[parameters('propertyArray')[copyIndex('loop1')].name]"
+                        }
+                    },
+                    {
+                        "name": "loop2",
+                        "count": "[length(parameters('propertyArray'))]",
+                        "input": {
+                            "key1": "[parameters('propertyArray')[copyIndex('loop2')].name]"
+                        }
+                    },
+                    {
+                        "name": "loop3",
+                        "count": "[length(parameters('propertyArray'))]",
+                        "input": {
+                            "key1": "[parameters('propertyArray')[copyIndex('loop3')].name]"
+                        }
+                    },
+                    {
+                        "name": "loop4",
+                        "count": "[length(parameters('propertyArray'))]",
+                        "input": {
+                            "key1": "[parameters('propertyArray')[copyIndex('loop4')].name]"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -52,6 +52,13 @@ namespace PSRule.Rules.Azure
             Assert.NotNull(resources);
         }
 
+        [Fact]
+        public void AdvancedTemplateParsing3()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Template.Parsing.1.json"), null);
+            Assert.NotNull(resources);
+        }
+
         private static string GetSourcePath(string fileName)
         {
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);


### PR DESCRIPTION
## PR Summary

- Fixed copy loop value does not fall within the expected range. #664
- Fixed template comparison functions handling of large integer values. #666
- Fixed handling of `createArray` function with no arguments. #667

Fixes #664 
Fixes #666 
Fixes #667 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
