### PR TITLE
Release v1.1.0

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+## v1.1.0
+
+What's changed since v1.0.0:
+
+- New features:
+  - Exporting template with `Export-AzRuleTemplateData` supports custom resource group and subscription. [#651](https://github.com/microsoft/PSRule.Rules.Azure/issues/651)
+    - Subscription and resource group used for deployment can be specified instead of using defaults.
+    - `ResourceGroupName` parameter of `Export-AzRuleTemplateData` has been renamed to `ResourceGroup`.
+    - Added a parameter alias for `ResourceGroupName` on `Export-AzRuleTemplateData`.
+- New rules:
+  - All resources:
+    - Check template parameters are defined. [#631](https://github.com/microsoft/PSRule.Rules.Azure/issues/631)
+    - Check location parameter is type string. [#632](https://github.com/microsoft/PSRule.Rules.Azure/issues/632)
+    - Check template parameter `minValue` and `maxValue` constraints are valid. [#637](https://github.com/microsoft/PSRule.Rules.Azure/issues/637)
+    - Check template resources do not use hard coded locations. [#633](https://github.com/microsoft/PSRule.Rules.Azure/issues/633)
+    - Check resource group location not referenced instead of location parameter. [#634](https://github.com/microsoft/PSRule.Rules.Azure/issues/634)
+    - Check increased debug detail is disabled for nested deployments. [#638](https://github.com/microsoft/PSRule.Rules.Azure/issues/638)
+- General improvements:
+  - Added support for matching template by name. [#661](https://github.com/microsoft/PSRule.Rules.Azure/issues/661)
+    - `Get-AzRuleTemplateLink` discovers `<templateName>.json` from `<templateName>.parameters.json`.
+- Engineering:
+  - Bump PSRule dependency to v1.0.3. [#648](https://github.com/Microsoft/PSRule.Rules.Azure/issues/648)
+- Bug fixes:
+  - Fixed `Azure.VM.ADE` to limit rule to exports only. [#644](https://github.com/microsoft/PSRule.Rules.Azure/issues/644)
+  - Fixed `if` condition values evaluation order. [#652](https://github.com/microsoft/PSRule.Rules.Azure/issues/652)
+  - Fixed handling of `int` parameters with large values. [#653](https://github.com/microsoft/PSRule.Rules.Azure/issues/653)
+  - Fixed handling of expressions split over multiple lines. [#654](https://github.com/microsoft/PSRule.Rules.Azure/issues/654)
+  - Fixed handling of bool parameter values within logical expressions. [#655](https://github.com/microsoft/PSRule.Rules.Azure/issues/655)
+  - Fixed copy loop value does not fall within the expected range. [#664](https://github.com/microsoft/PSRule.Rules.Azure/issues/664)
+  - Fixed template comparison functions handling of large integer values. [#666](https://github.com/microsoft/PSRule.Rules.Azure/issues/666)
+  - Fixed handling of `createArray` function with no arguments. [#667](https://github.com/microsoft/PSRule.Rules.Azure/issues/667)
+
+What's changed since pre-release v1.1.0-B2102034:
+
+- No additional changes.
+
 ## v1.1.0-B2102034 (pre-release)
 
 What's changed since pre-release v1.1.0-B2102023:


### PR DESCRIPTION
## PR Summary

What's changed since v1.0.0:

- New features:
  - Exporting template with `Export-AzRuleTemplateData` supports custom resource group and subscription. #651
    - Subscription and resource group used for deployment can be specified instead of using defaults.
    - `ResourceGroupName` parameter of `Export-AzRuleTemplateData` has been renamed to `ResourceGroup`.
    - Added a parameter alias for `ResourceGroupName` on `Export-AzRuleTemplateData`.
- New rules:
  - All resources:
    - Check template parameters are defined. #631
    - Check location parameter is type string. #632
    - Check template parameter `minValue` and `maxValue` constraints are valid. #637
    - Check template resources do not use hard coded locations. #633
    - Check resource group location not referenced instead of location parameter. #634
    - Check increased debug detail is disabled for nested deployments. #638
- General improvements:
  - Added support for matching template by name. #661
    - `Get-AzRuleTemplateLink` discovers `<templateName>.json` from `<templateName>.parameters.json`.
- Engineering:
  - Bump PSRule dependency to v1.0.3. #648
- Bug fixes:
  - Fixed `Azure.VM.ADE` to limit rule to exports only. #644
  - Fixed `if` condition values evaluation order. #652
  - Fixed handling of `int` parameters with large values. #653
  - Fixed handling of expressions split over multiple lines. #654
  - Fixed handling of bool parameter values within logical expressions. #655
  - Fixed copy loop value does not fall within the expected range. #664
  - Fixed template comparison functions handling of large integer values. #666
  - Fixed handling of `createArray` function with no arguments. #667

What's changed since pre-release v1.1.0-B2102034:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
