### PR TITLE
Fixed parsing of property names for functions across multiple lines #683

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since v1.1.2:
+
+- Bug fixes:
+  - Fixed parsing of property names for functions across multiple lines. [#683](https://github.com/microsoft/PSRule.Rules.Azure/issues/683)
+
 ## v1.1.2
 
 What's changed since v1.1.1:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
@@ -26,10 +26,7 @@ namespace PSRule.Rules.Azure.Data.Template
         // The maximum length of a template expression
         private const int MaxLength = 24576;
 
-        private const char Whitespace = ' ';
-
         private const char Backslash = '\\';
-
         private const char Apostrophe = '\'';
         private const char Comma = ',';
         private const char Period = '.';
@@ -39,7 +36,7 @@ namespace PSRule.Rules.Azure.Data.Template
         private const char BracketClose = ']';
         private readonly static char[] FunctionNameStopCharacter = new char[] { '(', ']', '[', ')', '\'', ' ', ',' };
         private readonly static char[] StringStopCharacters = new char[] { '\'' };
-        private readonly static char[] PropertyStopCharacters = new char[] { '(', ']', '[', ',', ')', ' ', '\'', '.' };
+        private readonly static char[] PropertyStopCharacters = new char[] { '(', ']', '[', ',', ')', ' ', '\'', '.', '\r', '\n' };
 
         internal ExpressionStream(string expression)
         {

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.1.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.1.json
@@ -32,7 +32,9 @@
                         "name": "loop1",
                         "count": "[length(parameters('propertyArray'))]",
                         "input": {
-                            "key1": "[parameters('propertyArray')[copyIndex('loop1')].name]"
+                            "key1": "[
+                                parameters('propertyArray')[copyIndex('loop1')].name
+                            ]"
                         }
                     },
                     {
@@ -46,7 +48,9 @@
                         "name": "loop3",
                         "count": "[length(parameters('propertyArray'))]",
                         "input": {
-                            "key1": "[parameters('propertyArray')[copyIndex('loop3')].name]"
+                            "key1": "[
+                                parameters('propertyArray')[copyIndex('loop3')].name
+                            ]"
                         }
                     },
                     {

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.2.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.2.json
@@ -113,7 +113,9 @@
         "defaultAccessPolicies": [
             {
                 "objectId": "00000000-0000-0000-0000-000000000000",
-                "tenantId": "[subscription().tenantId]",
+                "tenantId": "[
+                    subscription().tenantId
+                ]",
                 "permissions": {
                     "secrets": [
                         "Get",


### PR DESCRIPTION
## PR Summary

- Fixed parsing of property names for functions across multiple lines. #683

Fixes #683 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
