### PR TITLE
Pass through metadata from parameter file #706

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+What's changed since v1.2.0:
+
+- General improvements:
+  - Additional metadata added in parameter file is passed through with `Get-AzRuleTemplateLink`. [#706](https://github.com/Microsoft/PSRule.Rules.Azure/issues/706)
+
 ## v1.2.0
 
 What's changed since v1.1.4:

--- a/src/PSRule.Rules.Azure/Data/Metadata/TemplateLink.cs
+++ b/src/PSRule.Rules.Azure/Data/Metadata/TemplateLink.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections;
+
 namespace PSRule.Rules.Azure.Data.Metadata
 {
     internal sealed class TemplateLink : ITemplateLink
@@ -9,6 +12,7 @@ namespace PSRule.Rules.Azure.Data.Metadata
         {
             TemplateFile = templateFile;
             ParameterFile = parameterFile;
+            Metadata = new Hashtable(StringComparer.OrdinalIgnoreCase);
         }
 
         public string Name { get; internal set; }
@@ -18,5 +22,7 @@ namespace PSRule.Rules.Azure.Data.Metadata
         public string TemplateFile { get; }
 
         public string ParameterFile { get; }
+
+        public Hashtable Metadata { get; }
     }
 }

--- a/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
@@ -109,6 +109,7 @@ namespace PSRule.Rules.Azure.Pipeline
                 if (TryStringProperty(metadata, PROPERTYNAME_DESCRIPTION, out string description))
                     templateLink.Description = description;
 
+                AddMetadata(templateLink, metadata);
                 Context.Writer.WriteObject(templateLink, false);
             }
             catch (InvalidOperationException ex)
@@ -264,6 +265,30 @@ namespace PSRule.Rules.Azure.Pipeline
         private static string TrimSlash(string path)
         {
             return string.IsNullOrEmpty(path) || path[0] != SLASH ? path : path.TrimStart(SLASH);
+        }
+
+        private static void AddMetadata(TemplateLink templateLink, JObject metadata)
+        {
+            if (metadata == null || templateLink == null)
+                return;
+
+            foreach (var prop in metadata.Properties())
+            {
+                switch (prop.Value.Type)
+                {
+                    case JTokenType.String:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<string>();
+                        break;
+
+                    case JTokenType.Integer:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<long>();
+                        break;
+
+                    case JTokenType.Boolean:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<bool>();
+                        break;
+                }
+            }
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -451,6 +451,7 @@ Describe 'Get-AzRuleTemplateLink' -Tag 'Cmdlet', 'Get-AzRuleTemplateLink' {
                 (Join-Path -Path $templateScanPath -ChildPath 'Resources.Parameters.json')
                 (Join-Path -Path $templateScanPath -ChildPath 'Resources.Parameters2.json')
             );
+            @($result | Where-Object { $_.Metadata['additional'] -eq 'metadata' }).Length | Should -Be 1;
 
             # Get Resources.Parameters.json or Resources.Parameters2.json files in shallow path
             $result = @(Get-AzRuleTemplateLink -Path $templateScanPath -InputPath './Resources.Parameters?.json');

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
@@ -2,7 +2,8 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "metadata": {
-        "template": "./Resources.Template.json"
+        "template": "./Resources.Template.json",
+        "additional": "metadata"
     },
     "parameters": {
         "vnetName": {


### PR DESCRIPTION
## PR Summary

- Additional metadata added in parameter file is passed through with `Get-AzRuleTemplateLink`. #706

Fixes #706 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
