### PR TITLE
Pre-release v1.3.0-B2104040

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,8 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+## v1.3.0-B2104040 (pre-release)
+
 What's changed since pre-release v1.3.0-B2104034:
 
 - Bug fixes:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.3.0-B2104034:

- Bug fixes:
  - Fixed could not load file or assembly YamlDotNet. #741
    - This fix pins the PSRule version to v1.2.0 until the next stable release of PSRule for Azure.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
