### PR TITLE
Bump PSRule dependency to v1.3.0 #749 #742

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,12 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.3.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.3.0. [#749](https://github.com/Microsoft/PSRule.Rules.Azure/issues/749)
+  - Bump YamlDotNet dependency to v11.1.1. [#742](https://github.com/Microsoft/PSRule.Rules.Azure/issues/742)
+
 ## v1.3.0
 
 What's changed since v1.2.1:

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -116,7 +116,7 @@ task VersionModule ModuleDependencies, {
     $manifest = Test-ModuleManifest -Path $manifestPath;
     $requiredModules = $manifest.RequiredModules | ForEach-Object -Process {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule'; RequiredVersion = '1.2.0' }
+            @{ ModuleName = 'PSRule'; ModuleVersion = '1.3.0' }
         }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
@@ -166,8 +166,8 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -RequiredVersion 1.2.0 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -RequiredVersion 1.2.0 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.3.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.3.0 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSRule -Verbose:$False;
 }

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,7 +16,7 @@ bugs:
   url: https://github.com/Microsoft/PSRule.Rules.Azure/issues
 
 modules:
-  PSRule: ^1.2.0
+  PSRule: ^1.3.0
 
 tasks:
   clear:

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.csproj
@@ -36,7 +36,7 @@ This project uses GitHub Issues to track bugs and feature requests. See GitHub p
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.3.0. #749
- Bump YamlDotNet dependency to v11.1.1. #742

Fixes #749 
Fixes #742

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
