### PR TITLE
Automatically expand parameters for analysis #772

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,13 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since pre-release v1.4.0-B2105027:
+
+- New features:
+  - Automatically expand template from parameter files for analysis. [#772](https://github.com/Microsoft/PSRule.Rules.Azure/issues/772)
+    - Previously templates needed to be exported with `Export-AzRuleTemplateData`.
+    - To export template data automatically use PSRule cmdlets with `-Format File`.
+
 ## v1.4.0-B2105027 (pre-release)
 
 What's changed since pre-release v1.4.0-B2105020:

--- a/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ConfigurationOption.cs
@@ -55,9 +55,9 @@ namespace PSRule.Rules.Azure.Configuration
 
         internal static ConfigurationOption Combine(ConfigurationOption o1, ConfigurationOption o2)
         {
-            var result = new ConfigurationOption(o1);
-            result.ResourceGroup = o1.ResourceGroup ?? o2.ResourceGroup;
-            result.Subscription = o1.Subscription ?? o2.Subscription;
+            var result = new ConfigurationOption();
+            result.ResourceGroup = ResourceGroupOption.Combine(o1?.ResourceGroup, o2?.ResourceGroup);
+            result.Subscription = SubscriptionOption.Combine(o1?.Subscription, o2?.Subscription);
             return result;
         }
 

--- a/src/PSRule.Rules.Azure/Configuration/PSRuleOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/PSRuleOption.cs
@@ -71,7 +71,6 @@ namespace PSRule.Rules.Azure.Configuration
                 _GetWorkingPath = () => Directory.GetCurrentDirectory();
                 return;
             }
-            
             _GetWorkingPath = () => executionContext.SessionState.Path.CurrentFileSystemLocation.Path;
         }
 
@@ -101,8 +100,8 @@ namespace PSRule.Rules.Azure.Configuration
         private static PSRuleOption Combine(PSRuleOption o1, PSRuleOption o2)
         {
             var result = new PSRuleOption(o1?.SourcePath ?? o2?.SourcePath, o1);
-            result.Configuration = ConfigurationOption.Combine(result.Configuration, o2?.Configuration);
-            result.Output = OutputOption.Combine(result.Output, o2?.Output);
+            result.Configuration = ConfigurationOption.Combine(o1?.Configuration, o2?.Configuration);
+            result.Output = OutputOption.Combine(o1?.Output, o2?.Output);
             return result;
         }
 

--- a/src/PSRule.Rules.Azure/Configuration/ResourceGroupOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/ResourceGroupOption.cs
@@ -113,12 +113,12 @@ namespace PSRule.Rules.Azure.Configuration
         {
             var result = new ResourceGroupOption()
             {
-                SubscriptionId = o1.SubscriptionId ?? o2.SubscriptionId,
-                Name = o1.Name ?? o2.Name,
-                Location = o1.Location ?? o2.Location,
-                ManagedBy = o1.ManagedBy ?? o2.ManagedBy,
-                Tags = o1.Tags ?? o2.Tags,
-                Properties = o1.Properties ?? o2.Properties,
+                SubscriptionId = o1?.SubscriptionId ?? o2?.SubscriptionId,
+                Name = o1?.Name ?? o2?.Name,
+                Location = o1?.Location ?? o2?.Location,
+                ManagedBy = o1?.ManagedBy ?? o2?.ManagedBy,
+                Tags = o1?.Tags ?? o2?.Tags,
+                Properties = o1?.Properties ?? o2?.Properties,
             };
             return result;
         }

--- a/src/PSRule.Rules.Azure/Configuration/SubscriptionOption.cs
+++ b/src/PSRule.Rules.Azure/Configuration/SubscriptionOption.cs
@@ -84,10 +84,10 @@ namespace PSRule.Rules.Azure.Configuration
         {
             var result = new SubscriptionOption()
             {
-                SubscriptionId = o1.SubscriptionId ?? o2.SubscriptionId,
-                TenantId = o1.TenantId ?? o2.TenantId,
-                DisplayName = o1.DisplayName ?? o2.DisplayName,
-                State = o1.State ?? o2.State,
+                SubscriptionId = o1?.SubscriptionId ?? o2?.SubscriptionId,
+                TenantId = o1?.TenantId ?? o2?.TenantId,
+                DisplayName = o1?.DisplayName ?? o2?.DisplayName,
+                State = o1?.State ?? o2?.State,
             };
             return result;
         }

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateHelper.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PSRule.Rules.Azure.Configuration;
+using PSRule.Rules.Azure.Pipeline;
+using PSRule.Rules.Azure.Resources;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using System.Threading;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal sealed class TemplateHelper
+    {
+        private readonly PipelineContext Context;
+        private readonly string _DeploymentName;
+        private readonly ResourceGroupOption _ResourceGroup;
+        private readonly SubscriptionOption _Subscription;
+
+        public TemplateHelper(PipelineContext context, string deploymentName, ResourceGroupOption resourceGroup, SubscriptionOption subscription)
+        {
+            Context = context;
+            _DeploymentName = deploymentName;
+            _ResourceGroup = resourceGroup;
+            _Subscription = subscription;
+        }
+
+        internal PSObject[] ProcessTemplate(string templateFile, string parameterFile)
+        {
+            var rootedTemplateFile = PSRuleOption.GetRootedPath(templateFile);
+            if (!File.Exists(rootedTemplateFile))
+                throw new FileNotFoundException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.TemplateFileNotFound, rootedTemplateFile), rootedTemplateFile);
+
+            var templateObject = ReadFile(rootedTemplateFile);
+            var visitor = new RuleDataExportVisitor();
+
+            // Load context
+            var context = new TemplateVisitor.TemplateContext(Context, _Subscription, _ResourceGroup);
+            if (!string.IsNullOrEmpty(parameterFile))
+            {
+                var rootedParameterFile = PSRuleOption.GetRootedPath(parameterFile);
+                if (!File.Exists(rootedParameterFile))
+                    throw new FileNotFoundException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ParameterFileNotFound, rootedParameterFile), rootedParameterFile);
+
+                try
+                {
+                    var parametersObject = ReadFile(rootedParameterFile);
+                    context.Load(parametersObject);
+                }
+                catch (Exception inner)
+                {
+                    throw new TemplateReadException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.TemplateExpandInvalid, templateFile, parameterFile, inner.Message), inner, templateFile, parameterFile);
+                }
+            }
+
+            // Process
+            try
+            {
+                visitor.Visit(context, _DeploymentName, templateObject);
+            }
+            catch (Exception inner)
+            {
+                throw new TemplateReadException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.TemplateExpandInvalid, templateFile, parameterFile, inner.Message), inner, templateFile, parameterFile);
+            }
+
+            // Return results
+            var results = new List<PSObject>();
+            var serializer = new JsonSerializer();
+            serializer.Converters.Add(new PSObjectJsonConverter());
+            foreach (var resource in context.GetResources())
+                results.Add(resource.Value.ToObject<PSObject>(serializer));
+
+            return results.ToArray();
+        }
+
+        private static JObject ReadFile(string path)
+        {
+            using (var stream = new StreamReader(path))
+            {
+                using (var reader = new JsonTextReader(stream))
+                {
+                    return JObject.Load(reader);
+                }
+            }
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateLinkHelper.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateLinkHelper.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PSRule.Rules.Azure.Configuration;
+using PSRule.Rules.Azure.Data.Metadata;
+using PSRule.Rules.Azure.Pipeline;
+using PSRule.Rules.Azure.Resources;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    internal sealed class TemplateLinkHelper
+    {
+        private const string PROPERTYNAME_SCHEMA = "$schema";
+        private const string PROPERTYNAME_METADATA = "metadata";
+        private const string PROPERTYNAME_TEMPLATE = "template";
+        private const string PROPERTYNAME_NAME = "name";
+        private const string PROPERTYNAME_DESCRIPTION = "description";
+
+        private const string PARAMETER_FILE_SUFFIX = ".parameters.json";
+
+        private const char SLASH = '/';
+
+        private readonly bool _SkipUnlinked;
+        private readonly PipelineContext Context;
+
+        public TemplateLinkHelper(PipelineContext context, string basePath, bool skipUnlinked)
+        {
+            Context = context;
+            _SkipUnlinked = skipUnlinked;
+        }
+
+        internal TemplateLink ProcessParameterFile(string parameterFile)
+        {
+            // Check that the JSON file is an ARM template parameter file
+            var rootedParameterFile = PSRuleOption.GetRootedPath(parameterFile);
+            var parameterObject = ReadFile(rootedParameterFile);
+            if (parameterObject == null || !IsParameterFile(parameterObject))
+                return null;
+
+            // Check if metadata property exists
+            if (!((TryMetadata(parameterObject, rootedParameterFile, out JObject metadata, out string templateFile)) || TryTemplateByName(parameterFile, out templateFile)))
+            {
+                if (metadata == null && !_SkipUnlinked)
+                    throw new InvalidTemplateLinkException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.MetadataNotFound, parameterFile));
+
+                if (templateFile == null && !_SkipUnlinked)
+                    throw new InvalidTemplateLinkException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateLinkNotFound, parameterFile));
+
+                return null;
+            }
+
+            var templateLink = new TemplateLink(templateFile, rootedParameterFile);
+
+            // Populate remaining properties
+            if (TryStringProperty(metadata, PROPERTYNAME_NAME, out string name))
+                templateLink.Name = name;
+
+            if (TryStringProperty(metadata, PROPERTYNAME_DESCRIPTION, out string description))
+                templateLink.Description = description;
+
+            AddMetadata(templateLink, metadata);
+            return templateLink;
+        }
+
+        private static JObject ReadFile(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                throw new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.ParameterFileNotFound, path), path);
+
+            try
+            {
+                return JsonConvert.DeserializeObject(File.ReadAllText(path)) as JObject;
+            }
+            catch (InvalidCastException)
+            {
+                // Discard exception
+                return null;
+            }
+            catch (Exception inner)
+            {
+                throw new TemplateReadException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.JsonFileFormatInvalid, path, inner.Message), inner, path, null);
+            }
+        }
+
+        /// <summary>
+        /// Check the JSON object is an ARM template parameter file.
+        /// </summary>
+        private static bool IsParameterFile(JObject value)
+        {
+            if (!value.TryGetValue(PROPERTYNAME_SCHEMA, out JToken token) || !Uri.TryCreate(token.Value<string>(), UriKind.Absolute, out Uri schemaUri))
+                return false;
+
+            return StringComparer.OrdinalIgnoreCase.Equals(schemaUri.Host, "schema.management.azure.com") &&
+                schemaUri.PathAndQuery.StartsWith("/schemas/", StringComparison.OrdinalIgnoreCase) &&
+                IsDeploymentParameterFile(schemaUri);
+        }
+
+        private static bool IsDeploymentParameterFile(Uri schemaUri)
+        {
+            return schemaUri.PathAndQuery.EndsWith("/deploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
+                schemaUri.PathAndQuery.EndsWith("/subscriptionDeploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
+                schemaUri.PathAndQuery.EndsWith("/managementGroupDeploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
+                schemaUri.PathAndQuery.EndsWith("/tenantDeploymentParameters.json", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool TryMetadata(JObject parameterObject, string parameterFile, out JObject metadata, out string templateFile)
+        {
+            metadata = null;
+            templateFile = null;
+            if (parameterObject.TryGetValue(PROPERTYNAME_METADATA, out JToken metadataToken) && metadataToken is JObject property)
+            {
+                metadata = property;
+                return TryTemplateFile(metadata, parameterFile, out templateFile);
+            }
+            Context.Writer.VerboseMetadataNotFound(parameterFile);
+            return false;
+        }
+
+        private bool TryTemplateFile(JObject metadata, string parameterFile, out string templateFile)
+        {
+            if (!TryStringProperty(metadata, PROPERTYNAME_TEMPLATE, out templateFile))
+            {
+                if (_SkipUnlinked)
+                    Context.Writer.VerboseTemplateLinkNotFound(parameterFile);
+
+                return false;
+            }
+
+            templateFile = TrimSlash(templateFile);
+            var pathBase = IsRelative(templateFile) ? Path.GetDirectoryName(parameterFile) : PSRuleOption.GetWorkingPath();
+            templateFile = Path.GetFullPath(Path.Combine(pathBase, templateFile));
+
+            // Template file must be within working path
+            if (!templateFile.StartsWith(PSRuleOption.GetRootedBasePath(""), StringComparison.Ordinal))
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.PathTraversal, templateFile));
+
+            if (!File.Exists(templateFile))
+            {
+                Context.Writer.VerboseTemplateFileNotFound(templateFile);
+                throw new FileNotFoundException(
+                    string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateFileReferenceNotFound, parameterFile),
+                    new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateFileNotFound, templateFile))
+                );
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Try to match using templateName.parameters.json.
+        /// </summary>
+        private static bool TryTemplateByName(string parameterFile, out string templateFile)
+        {
+            templateFile = null;
+            var parentPath = Path.GetDirectoryName(parameterFile);
+            var parameterPrefix = Path.GetFileName(parameterFile);
+            if (string.IsNullOrEmpty(parameterPrefix) || string.IsNullOrEmpty(parentPath) || parameterPrefix.Length <= 16 || !parameterPrefix.EndsWith(PARAMETER_FILE_SUFFIX, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            parameterPrefix = parameterPrefix.Remove(parameterPrefix.Length - 16, 11);
+            templateFile = Path.Combine(parentPath, parameterPrefix);
+            return File.Exists(templateFile);
+        }
+
+        private static bool TryStringProperty(JObject o, string propertyName, out string value)
+        {
+            value = null;
+            return o != null && o.TryGetValue(propertyName, out JToken token) && TryString(token, out value);
+        }
+
+        private static bool TryString(JToken token, out string value)
+        {
+            value = null;
+            if (token == null || token.Type != JTokenType.String)
+                return false;
+
+            value = token.Value<string>();
+            return true;
+        }
+
+        private static bool IsRelative(string path)
+        {
+            return path.StartsWith("./", StringComparison.OrdinalIgnoreCase) || path.StartsWith("../", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string TrimSlash(string path)
+        {
+            return string.IsNullOrEmpty(path) || path[0] != SLASH ? path : path.TrimStart(SLASH);
+        }
+
+        private static void AddMetadata(TemplateLink templateLink, JObject metadata)
+        {
+            if (metadata == null || templateLink == null)
+                return;
+
+            foreach (var prop in metadata.Properties())
+            {
+                switch (prop.Value.Type)
+                {
+                    case JTokenType.String:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<string>();
+                        break;
+
+                    case JTokenType.Integer:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<long>();
+                        break;
+
+                    case JTokenType.Boolean:
+                        templateLink.Metadata[prop.Name] = prop.Value.Value<bool>();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/PSRule.Rules.Azure/Pipeline/LoggingExtensions.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/LoggingExtensions.cs
@@ -12,26 +12,41 @@ namespace PSRule.Rules.Azure.Pipeline
     {
         internal static void VerboseFindFiles(this ILogger logger, string path)
         {
+            if (logger == null)
+                return;
+
             logger.WriteVerbose(Diagnostics.VerboseFindFiles, path);
         }
 
         internal static void VerboseFoundFile(this ILogger logger, string path)
         {
+            if (logger == null)
+                return;
+
             logger.WriteVerbose(Diagnostics.VerboseFoundFile, path);
         }
 
         internal static void VerboseMetadataNotFound(this ILogger logger, string path)
         {
+            if (logger == null)
+                return;
+
             logger.WriteVerbose(Diagnostics.VerboseMetadataNotFound, path);
         }
 
         internal static void VerboseTemplateLinkNotFound(this ILogger logger, string path)
         {
+            if (logger == null)
+                return;
+
             logger.WriteVerbose(Diagnostics.VerboseTemplateLinkNotFound, path);
         }
 
         internal static void VerboseTemplateFileNotFound(this ILogger logger, string path)
         {
+            if (logger == null)
+                return;
+
             logger.WriteVerbose(Diagnostics.VerboseTemplateFileNotFound, path);
         }
     }

--- a/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplateLinkPipeline.cs
@@ -1,16 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using PSRule.Rules.Azure.Configuration;
-using PSRule.Rules.Azure.Data.Metadata;
-using PSRule.Rules.Azure.Resources;
+using PSRule.Rules.Azure.Data.Template;
 using System;
-using System.Globalization;
 using System.IO;
 using System.Management.Automation;
-using System.Threading;
 
 namespace PSRule.Rules.Azure.Pipeline
 {
@@ -43,28 +38,18 @@ namespace PSRule.Rules.Azure.Pipeline
 
     internal sealed class TemplateLinkPipeline : PipelineBase
     {
-        private const string PROPERTYNAME_SCHEMA = "$schema";
-        private const string PROPERTYNAME_METADATA = "metadata";
-        private const string PROPERTYNAME_TEMPLATE = "template";
-        private const string PROPERTYNAME_NAME = "name";
-        private const string PROPERTYNAME_DESCRIPTION = "description";
-
         private const string DEFAULT_TEMPLATESEARCH_PATTERN = "*.parameters.json";
 
-        private const string PARAMETER_FILE_SUFFIX = ".parameters.json";
-
-        private const char SLASH = '/';
-
         private readonly string _BasePath;
-        private readonly bool _SkipUnlinked;
         private readonly PathBuilder _PathBuilder;
+        private readonly TemplateLinkHelper _TemplateHelper;
 
         internal TemplateLinkPipeline(PipelineContext context, string basePath, bool skipUnlinked)
             : base(context)
         {
             _BasePath = PSRuleOption.GetRootedBasePath(basePath);
-            _SkipUnlinked = skipUnlinked;
             _PathBuilder = new PathBuilder(context.Writer, basePath, DEFAULT_TEMPLATESEARCH_PATTERN);
+            _TemplateHelper = new TemplateLinkHelper(context, _BasePath, skipUnlinked);
         }
 
         public override void Process(PSObject sourceObject)
@@ -82,34 +67,7 @@ namespace PSRule.Rules.Azure.Pipeline
         {
             try
             {
-                // Check that the JSON file is an ARM template parameter file
-                var rootedParameterFile = PSRuleOption.GetRootedPath(parameterFile);
-                var parameterObject = ReadFile<JObject>(rootedParameterFile);
-                if (parameterObject == null || !IsParameterFile(parameterObject))
-                    return;
-
-                // Check if metadata property exists
-                if (!((TryMetadata(parameterObject, rootedParameterFile, out JObject metadata, out string templateFile)) || TryTemplateByName(parameterFile, out templateFile)))
-                {
-                    if (metadata == null && !_SkipUnlinked)
-                        throw new InvalidTemplateLinkException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.MetadataNotFound, parameterFile));
-
-                    if (templateFile == null && !_SkipUnlinked)
-                        throw new InvalidTemplateLinkException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateLinkNotFound, parameterFile));
-
-                    return;
-                }
-
-                var templateLink = new TemplateLink(templateFile, rootedParameterFile);
-
-                // Populate remaining properties
-                if (TryStringProperty(metadata, PROPERTYNAME_NAME, out string name))
-                    templateLink.Name = name;
-
-                if (TryStringProperty(metadata, PROPERTYNAME_DESCRIPTION, out string description))
-                    templateLink.Description = description;
-
-                AddMetadata(templateLink, metadata);
+                var templateLink = _TemplateHelper.ProcessParameterFile(parameterFile);
                 Context.Writer.WriteObject(templateLink, false);
             }
             catch (InvalidOperationException ex)
@@ -140,155 +98,6 @@ namespace PSRule.Rules.Azure.Pipeline
                 return true;
             }
             return false;
-        }
-
-        private static T ReadFile<T>(string path)
-        {
-            if (string.IsNullOrEmpty(path) || !File.Exists(path))
-                throw new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.ParameterFileNotFound, path), path);
-
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(File.ReadAllText(path));
-            }
-            catch (InvalidCastException)
-            {
-                // Discard exception
-                return default(T);
-            }
-            catch (Exception inner)
-            {
-                throw new TemplateReadException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.JsonFileFormatInvalid, path, inner.Message), inner, path, null);
-            }
-        }
-
-        /// <summary>
-        /// Check the JSON object is an ARM template parameter file.
-        /// </summary>
-        private static bool IsParameterFile(JObject value)
-        {
-            if (!value.TryGetValue(PROPERTYNAME_SCHEMA, out JToken token) || !Uri.TryCreate(token.Value<string>(), UriKind.Absolute, out Uri schemaUri))
-                return false;
-
-            return StringComparer.OrdinalIgnoreCase.Equals(schemaUri.Host, "schema.management.azure.com") &&
-                schemaUri.PathAndQuery.StartsWith("/schemas/", StringComparison.OrdinalIgnoreCase) &&
-                IsDeploymentParameterFile(schemaUri);
-        }
-
-        private static bool IsDeploymentParameterFile(Uri schemaUri)
-        {
-            return schemaUri.PathAndQuery.EndsWith("/deploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
-                schemaUri.PathAndQuery.EndsWith("/subscriptionDeploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
-                schemaUri.PathAndQuery.EndsWith("/managementGroupDeploymentParameters.json", StringComparison.OrdinalIgnoreCase) ||
-                schemaUri.PathAndQuery.EndsWith("/tenantDeploymentParameters.json", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private bool TryMetadata(JObject parameterObject, string parameterFile, out JObject metadata, out string templateFile)
-        {
-            metadata = null;
-            templateFile = null;
-            if (parameterObject.TryGetValue(PROPERTYNAME_METADATA, out JToken metadataToken) && metadataToken is JObject property)
-            {
-                metadata = property;
-                return TryTemplateFile(metadata, parameterFile, out templateFile);
-            }
-            Context.Writer.VerboseMetadataNotFound(parameterFile);
-            return false;
-        }
-
-        private bool TryTemplateFile(JObject metadata, string parameterFile, out string templateFile)
-        {
-            if (!TryStringProperty(metadata, PROPERTYNAME_TEMPLATE, out templateFile))
-            {
-                if (_SkipUnlinked)
-                    Context.Writer.VerboseTemplateLinkNotFound(parameterFile);
-
-                return false;
-            }
-
-            templateFile = TrimSlash(templateFile);
-            var pathBase = IsRelative(templateFile) ? Path.GetDirectoryName(parameterFile) : PSRuleOption.GetWorkingPath();
-            templateFile = Path.GetFullPath(Path.Combine(pathBase, templateFile));
-
-            // Template file must be within working path
-            if (!templateFile.StartsWith(PSRuleOption.GetRootedBasePath(""), StringComparison.Ordinal))
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.PathTraversal, templateFile));
-
-            if (!File.Exists(templateFile))
-            {
-                Context.Writer.VerboseTemplateFileNotFound(templateFile);
-                throw new FileNotFoundException(
-                    string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateFileReferenceNotFound, parameterFile),
-                    new FileNotFoundException(string.Format(CultureInfo.CurrentCulture, PSRuleResources.TemplateFileNotFound, templateFile))
-                );
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// Try to match using templateName.parameters.json.
-        /// </summary>
-        private static bool TryTemplateByName(string parameterFile, out string templateFile)
-        {
-            templateFile = null;
-            var parentPath = Path.GetDirectoryName(parameterFile);
-            var parameterPrefix = Path.GetFileName(parameterFile);
-            if (string.IsNullOrEmpty(parameterPrefix) || string.IsNullOrEmpty(parentPath) || parameterPrefix.Length <= 16 || !parameterPrefix.EndsWith(PARAMETER_FILE_SUFFIX, StringComparison.OrdinalIgnoreCase))
-                return false;
-
-            parameterPrefix = parameterPrefix.Remove(parameterPrefix.Length - 16, 11);
-            templateFile = Path.Combine(parentPath, parameterPrefix);
-            return File.Exists(templateFile);
-        }
-
-        private static bool TryStringProperty(JObject o, string propertyName, out string value)
-        {
-            value = null;
-            return o != null && o.TryGetValue(propertyName, out JToken token) && TryString(token, out value);
-        }
-
-        private static bool TryString(JToken token, out string value)
-        {
-            value = null;
-            if (token == null || token.Type != JTokenType.String)
-                return false;
-
-            value = token.Value<string>();
-            return true;
-        }
-
-        private static bool IsRelative(string path)
-        {
-            return path.StartsWith("./", StringComparison.OrdinalIgnoreCase) || path.StartsWith("../", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static string TrimSlash(string path)
-        {
-            return string.IsNullOrEmpty(path) || path[0] != SLASH ? path : path.TrimStart(SLASH);
-        }
-
-        private static void AddMetadata(TemplateLink templateLink, JObject metadata)
-        {
-            if (metadata == null || templateLink == null)
-                return;
-
-            foreach (var prop in metadata.Properties())
-            {
-                switch (prop.Value.Type)
-                {
-                    case JTokenType.String:
-                        templateLink.Metadata[prop.Name] = prop.Value.Value<string>();
-                        break;
-
-                    case JTokenType.Integer:
-                        templateLink.Metadata[prop.Name] = prop.Value.Value<long>();
-                        break;
-
-                    case JTokenType.Boolean:
-                        templateLink.Metadata[prop.Name] = prop.Value.Value<bool>();
-                        break;
-                }
-            }
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Runtime/Helper.cs
+++ b/src/PSRule.Rules.Azure/Runtime/Helper.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Rules.Azure.Configuration;
 using PSRule.Rules.Azure.Data.Template;
+using PSRule.Rules.Azure.Pipeline;
+using System.Management.Automation;
 
 namespace PSRule.Rules.Azure.Runtime
 {
@@ -21,6 +24,26 @@ namespace PSRule.Rules.Azure.Runtime
         public static bool IsTemplateExpression(string expression)
         {
             return ExpressionParser.IsExpression(expression);
+        }
+
+        public static PSObject[] GetResources(string parameterFile)
+        {
+            var context = GetContext();
+
+            var linkHelper = new TemplateLinkHelper(context, PSRuleOption.GetWorkingPath(), true);
+            var link = linkHelper.ProcessParameterFile(parameterFile);
+            if (link == null)
+                return null;
+
+            var helper = new TemplateHelper(context, "helper", context.Option.Configuration.ResourceGroup, context.Option.Configuration.Subscription);
+            return helper.ProcessTemplate(link.TemplateFile, link.ParameterFile);
+        }
+
+        private static PipelineContext GetContext()
+        {
+            var option = PSRuleOption.FromFileOrDefault(PSRuleOption.GetWorkingPath());
+            var context = new PipelineContext(option, null);
+            return context;
         }
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -24,6 +24,9 @@ spec:
       resourceId: [ 'ResourceId' ]
       subscriptionId: [ 'SubscriptionId' ]
       resourceGroupName: [ 'ResourceGroupName' ]
+  convention:
+    include:
+    - 'Azure.ExpandTemplate'
   output:
     culture:
     - en

--- a/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Conventions definitions
+#
+
+# Synopsis: Expand Azure resources from parameter files.
+Export-PSRuleConvention 'Azure.ExpandTemplate' -If { $TargetObject.Extension -eq '.json' -and $Assert.HasJsonSchema($PSRule.GetContentFirstOrDefault($TargetObject), @(
+    "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json`#"
+    "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json`#"
+), $True) } -Begin {
+    Write-Verbose "[Azure.ExpandTemplate] -- Expanding parameter file: $($TargetObject.FullName)";
+    try {
+        $data = [PSRule.Rules.Azure.Runtime.Helper]::GetResources($TargetObject.FullName);
+        if ($Null -ne $data) {
+            $PSRule.Import($data);
+        }
+    }
+    catch [PSRule.Rules.Azure.Data.Template.TemplateException] {
+        Write-Error -Exception $_.Exception;
+    }
+    catch [PSRule.Rules.Azure.Pipeline.TemplateReadException] {
+        Write-Error -Exception $_.Exception;
+    }
+    catch [System.IO.FileNotFoundException] {
+        Write-Error -Exception $_.Exception;
+    }
+    catch {
+        Write-Error -Message "Failed to expand parameter file '$($TargetObject.FullName)'. $($_.Exception.Message)" -ErrorId 'Azure.ExpandTemplate.ConventionException';
+    }
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Unit tests for Azure conventions
+#
+
+[CmdletBinding()]
+param ()
+
+# Setup error handling
+$ErrorActionPreference = 'Stop';
+Set-StrictMode -Version latest;
+
+if ($Env:SYSTEM_DEBUG -eq 'true') {
+    $VerbosePreference = 'Continue';
+}
+
+# Setup tests paths
+$rootPath = $PWD;
+Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
+$here = (Resolve-Path $PSScriptRoot).Path;
+
+Describe 'Azure.ExpandTemplate' -Tag 'Convention' {
+    Context 'Convention' {
+        It 'Expands template parameter files' {
+            $invokeParams = @{
+                Baseline = 'Azure.All'
+                Module = 'PSRule.Rules.Azure'
+                WarningAction = 'Ignore'
+                ErrorAction = 'Stop'
+            }
+
+            $parameterFile = Join-Path -Path $here -ChildPath 'Resources.Storage.Parameters.json';
+            $result = @(Invoke-PSRule @invokeParams -InputPath $parameterFile -Format File);
+            $result.Length | Should -BeGreaterThan 1;
+
+            $resource = $result | Where-Object { $_.TargetType -eq 'Microsoft.Storage/storageAccounts' };
+            $resource | Should -Not -BeNullOrEmpty;
+            $resource.TargetName | Should -BeIn 'storage1'
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Automatically expand template from parameter files for analysis. #772
  - Previously templates needed to be exported with `Export-AzRuleTemplateData`.
  - To export template data automatically use PSRule cmdlets with `-Format File`.

Fixes #772 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
