### PR TITLE
Fix string index parsing with whitespace #775

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,6 +13,8 @@ What's changed since pre-release v1.4.0-B2105027:
   - Automatically expand template from parameter files for analysis. [#772](https://github.com/Microsoft/PSRule.Rules.Azure/issues/772)
     - Previously templates needed to be exported with `Export-AzRuleTemplateData`.
     - To export template data automatically use PSRule cmdlets with `-Format File`.
+- Bug fixes:
+  - Fixed string index parsing in expressions with whitespace. [#775](https://github.com/Microsoft/PSRule.Rules.Azure/issues/775)
 
 ## v1.4.0-B2105027 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionParser.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionParser.cs
@@ -125,6 +125,7 @@ namespace PSRule.Rules.Azure.Data.Template
         /// </summary>
         private static void Inner(ExpressionStream stream, TokenStream output)
         {
+            stream.SkipWhitespace();
             if (stream.CaptureString(out string s))
             {
                 output.String(s);

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
@@ -150,7 +150,7 @@ namespace PSRule.Rules.Azure
         }
 
         [Fact]
-        public void ParseExpression8()
+        public void ParseExpressionMultiline()
         {
             var expression = "[\r\nparameters(\r\n                 'vnetName'\r\n)\r\n]";
             var actual = ExpressionParser.Parse(expression).ToArray();
@@ -160,6 +160,35 @@ namespace PSRule.Rules.Azure
             Assert.Equal(ExpressionTokenType.String, actual[2].Type); // 'vnetName'
             Assert.Equal("vnetName", actual[2].Content);
             Assert.Equal(ExpressionTokenType.GroupEnd, actual[3].Type);
+        }
+
+        [Fact]
+        public void ParseExpressionWithStringIndexProperty()
+        {
+            var expression = "[ variables('configurations')[ variables('environment') ][ 'defaults' ][\r\n'item1'] ]";
+            var actual = ExpressionParser.Parse(expression).ToArray();
+
+            Assert.Equal(ExpressionTokenType.Element, actual[0].Type); // variables
+            Assert.Equal("variables", actual[0].Content);
+            Assert.Equal(ExpressionTokenType.GroupStart, actual[1].Type);
+            Assert.Equal(ExpressionTokenType.String, actual[2].Type); // 'configurations'
+            Assert.Equal("configurations", actual[2].Content);
+            Assert.Equal(ExpressionTokenType.GroupEnd, actual[3].Type);
+            Assert.Equal(ExpressionTokenType.IndexStart, actual[4].Type);
+            Assert.Equal(ExpressionTokenType.Element, actual[5].Type);
+            Assert.Equal(ExpressionTokenType.GroupStart, actual[6].Type);
+            Assert.Equal(ExpressionTokenType.String, actual[7].Type); // 'environment'
+            Assert.Equal("environment", actual[7].Content);
+            Assert.Equal(ExpressionTokenType.GroupEnd, actual[8].Type);
+            Assert.Equal(ExpressionTokenType.IndexEnd, actual[9].Type);
+            Assert.Equal(ExpressionTokenType.IndexStart, actual[10].Type);
+            Assert.Equal(ExpressionTokenType.String, actual[11].Type); // 'defaults'
+            Assert.Equal("defaults", actual[11].Content);
+            Assert.Equal(ExpressionTokenType.IndexEnd, actual[12].Type);
+            Assert.Equal(ExpressionTokenType.IndexStart, actual[13].Type);
+            Assert.Equal(ExpressionTokenType.String, actual[14].Type); // 'item1'
+            Assert.Equal("item1", actual[14].Content);
+            Assert.Equal(ExpressionTokenType.IndexEnd, actual[15].Type);
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed string index parsing in expressions with whitespace. #775

Fixes #775 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
