### PR TITLE
Fixed base for DateTimeAdd not a valid string #777

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -15,6 +15,7 @@ What's changed since pre-release v1.4.0-B2105027:
     - To export template data automatically use PSRule cmdlets with `-Format File`.
 - Bug fixes:
   - Fixed string index parsing in expressions with whitespace. [#775](https://github.com/Microsoft/PSRule.Rules.Azure/issues/775)
+  - Fixed base for DateTimeAdd is not a valid string. [#777](https://github.com/Microsoft/PSRule.Rules.Azure/issues/777)
 
 ## v1.4.0-B2105027 (pre-release)
 

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -12,6 +12,8 @@ namespace PSRule.Rules.Azure.Data.Template
 {
     internal static class ExpressionHelpers
     {
+        private static readonly CultureInfo AzureCulture = new CultureInfo("en-US");
+
         internal static bool TryString(object o, out string value)
         {
             if (o is string s)
@@ -182,7 +184,39 @@ namespace PSRule.Rules.Azure.Data.Template
             if (TryString(o, out string svalue) && bool.TryParse(svalue, out value))
                 return true;
 
-            value = default(bool);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get DateTime from the existing object.
+        /// </summary>
+        internal static bool TryDateTime(object o, out DateTime value)
+        {
+            if (o is DateTime dvalue)
+            {
+                value = dvalue;
+                return true;
+            }
+            else if (o is JToken token && token.Type == JTokenType.Date)
+            {
+                value = token.Value<DateTime>();
+                return true;
+            }
+            value = default(DateTime);
+            return false;
+        }
+
+        /// <summary>
+        /// Try to get DateTime from the existing type and allow conversion from string.
+        /// </summary>
+        internal static bool TryConvertDateTime(object o, out DateTime value)
+        {
+            if (TryDateTime(o, out value))
+                return true;
+
+            if (TryString(o, out string svalue) && DateTime.TryParse(svalue, AzureCulture, DateTimeStyles.None, out value))
+                return true;
+
             return false;
         }
 

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -1096,7 +1096,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (argCount < 2 || argCount > 3)
                 throw ArgumentsOutOfRange(nameof(DateTimeAdd), args);
 
-            if (!ExpressionHelpers.TryString(args[0], out string start))
+            if (!ExpressionHelpers.TryConvertDateTime(args[0], out DateTime startTime))
                 throw ArgumentInvalidString(nameof(DateTimeAdd), "base");
 
             if (!ExpressionHelpers.TryString(args[1], out string duration))
@@ -1106,7 +1106,6 @@ namespace PSRule.Rules.Azure.Data.Template
             if (argCount == 3 && !ExpressionHelpers.TryString(args[2], out format))
                 throw ArgumentInvalidString(nameof(DateTimeAdd), nameof(format));
 
-            var startTime = DateTime.Parse(start, AzureCulture);
             var timeToAdd = XmlConvert.ToTimeSpan(duration);
             var result = startTime.Add(timeToAdd);
             return format == null ? result.ToString(AzureCulture) : result.ToString(format, AzureCulture);

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionBuilderTests.cs
@@ -80,6 +80,21 @@ namespace PSRule.Rules.Azure
             Assert.Throws<ArgumentOutOfRangeException>(() => Build(context, "[variables('items')[0]]"));
         }
 
+        [Fact]
+        public void BuildExpressionWithDateParameter()
+        {
+            var expression = "[dateTimeAdd(parameters('startDate'), parameters('duration'))]";
+            var context = GetContext();
+            var expected = JObject.Parse("{ \"value\": \"2021-05-01T00:00:00Z\", \"duration\": \"P10Y\" }");
+            Assert.Equal(JTokenType.Date, expected["value"].Type);
+            Assert.Equal(JTokenType.String, expected["duration"].Type);
+
+            context.Parameter("startDate", expected["value"]);
+            context.Parameter("duration", expected["duration"]);
+            var actual = Build(context, expression);
+            Assert.NotNull(actual);
+        }
+
         private static object Build(TemplateContext context, string expression)
         {
             var builder = new ExpressionBuilder();


### PR DESCRIPTION
## PR Summary

- Fixed base for DateTimeAdd is not a valid string. #777

Fixes #777

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
