### PR TITLE
AKS rules #436 #786 #787 #788 #789 #767

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -9,6 +9,16 @@ See [troubleshooting guide] for a workaround to this issue.
 
 What's changed since pre-release v1.4.0-B2105050:
 
+- New rules:
+  - Azure Kubernetes Service:
+    - Check clusters use AKS-managed Azure AD integration. [#436](https://github.com/microsoft/PSRule.Rules.Azure/issues/436)
+    - Check clusters have local account disabled (preview). [#786](https://github.com/microsoft/PSRule.Rules.Azure/issues/786)
+    - Check clusters have an auto-upgrade channel set (preview). [#787](https://github.com/microsoft/PSRule.Rules.Azure/issues/787)
+    - Check clusters limit access network access to the API server. [#788](https://github.com/microsoft/PSRule.Rules.Azure/issues/788)
+    - Check clusters used Azure RBAC for Kubernetes authorization. [#789](https://github.com/microsoft/PSRule.Rules.Azure/issues/789)
+- Updated rules
+  - Azure Kubernetes Service:
+    - Updated `Azure.AKS.Version` to 1.20.5. [#767](https://github.com/Microsoft/PSRule.Rules.Azure/issues/767)
 - Engineering:
   - Added source link to project. [#783](https://github.com/microsoft/PSRule.Rules.Azure/issues/783)
 

--- a/docs/baselines/en/Azure.All.md
+++ b/docs/baselines/en/Azure.All.md
@@ -4,7 +4,7 @@ Includes all Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.All`. This baseline includes a total of 204 rules.
+The following rules are included within `Azure.All`. This baseline includes a total of 209 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -18,8 +18,13 @@ Name | Synopsis | Severity
 [Azure.ACR.Quarantine](Azure.ACR.Quarantine.md) | Enable container image quarantine, scan, and mark images as verified. | Important
 [Azure.ACR.Retention](Azure.ACR.Retention.md) | Use a retention policy to cleanup untagged manifests. | Important
 [Azure.ACR.Usage](Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
+[Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
+[Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.LocalAccounts](Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
+[Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness

--- a/docs/baselines/en/Azure.Default.md
+++ b/docs/baselines/en/Azure.Default.md
@@ -4,7 +4,7 @@ Default baseline for Azure rules.
 
 ## Rules
 
-The following rules are included within `Azure.Default`. This baseline includes a total of 202 rules.
+The following rules are included within `Azure.Default`. This baseline includes a total of 205 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -16,8 +16,11 @@ Name | Synopsis | Severity
 [Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments. | Important
 [Azure.ACR.Name](Azure.ACR.Name.md) | Container registry names should meet naming requirements. | Awareness
 [Azure.ACR.Usage](Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
+[Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
+[Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness

--- a/docs/baselines/en/Azure.Preview.md
+++ b/docs/baselines/en/Azure.Preview.md
@@ -4,7 +4,7 @@ Includes Azure features in preview.
 
 ## Rules
 
-The following rules are included within `Azure.Preview`. This baseline includes a total of 204 rules.
+The following rules are included within `Azure.Preview`. This baseline includes a total of 209 rules.
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -18,8 +18,13 @@ Name | Synopsis | Severity
 [Azure.ACR.Quarantine](Azure.ACR.Quarantine.md) | Enable container image quarantine, scan, and mark images as verified. | Important
 [Azure.ACR.Retention](Azure.ACR.Retention.md) | Use a retention policy to cleanup untagged manifests. | Important
 [Azure.ACR.Usage](Azure.ACR.Usage.md) | Regularly remove deprecated and unneeded images to reduce storage usage. | Important
+[Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
+[Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.LocalAccounts](Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
+[Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness

--- a/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
@@ -42,15 +42,15 @@ Default:
 ```yaml
 # YAML: The default Azure_AKSMinimumVersion configuration option
 configuration:
-  Azure_AKSMinimumVersion: 1.19.7
+  Azure_AKSMinimumVersion: 1.20.5
 ```
 
 Example:
 
 ```yaml
-# YAML: Set the Azure_AKSMinimumVersion configuration option to 1.17.0
+# YAML: Set the Azure_AKSMinimumVersion configuration option to 1.19.7
 configuration:
-  Azure_AKSMinimumVersion: 1.17.0
+  Azure_AKSMinimumVersion: 1.19.7
 ```
 
 ### Azure_AKSNodeMinimumMaxPods

--- a/docs/rules/en/Azure.AKS.AuthorizedIPs.md
+++ b/docs/rules/en/Azure.AKS.AuthorizedIPs.md
@@ -1,0 +1,49 @@
+---
+severity: Important
+pillar: Security
+category: Design
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.AuthorizedIPs.md
+---
+
+# Restrict access to AKS API server endpoints
+
+## SYNOPSIS
+
+Restrict access to API server endpoints to authorized IP addresses.
+
+## DESCRIPTION
+
+In Kubernetes, the API server is the control plane of the cluster.
+Access to the API server is required by various cluster functions as well as all administrator activities.
+
+All activities performed against the cluster require authorization.
+To improve cluster security, the API server can be restricted to a limited set of IP address ranges.
+
+Restricting authorized IP addresses for the API server as the following limitations:
+
+- Requires AKS clusters configured with a Standard Load Balancer SKU.
+- This feature is not compatible with clusters that use Public IP per Node.
+
+When configuring this feature you must specify the IP address ranges that will be authorized.
+To allow only the outbound public IP of the Standard SKU load balancer, use `0.0.0.0/32`.
+
+## RECOMMENDATION
+
+Consider restricting network traffic to the API server endpoints to trusted IP addresses.
+Include output IP addresses for cluster nodes and any range where administration will occur from.
+
+## EXAMPLES
+
+### Configure with Azure CLI
+
+```bash
+az aks update -n '<name>' -g '<resource_group>' --api-server-authorized-ip-ranges '0.0.0.0/32'
+```
+
+## LINKS
+
+- [Network security](https://docs.microsoft.com/azure/architecture/framework/security/design-network)
+- [Secure access to the API server using authorized IP address ranges in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges)
+- [Best practices for cluster security and upgrades in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/operator-best-practices-cluster-security#secure-access-to-the-api-server-and-cluster-nodes)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/rules/en/Azure.AKS.AutoUpgrade.md
+++ b/docs/rules/en/Azure.AKS.AutoUpgrade.md
@@ -1,0 +1,140 @@
+---
+severity: Important
+pillar: Reliability
+category: Design
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.AutoUpgrade.md
+---
+
+# Set AKS auto-upgrade channel
+
+## SYNOPSIS
+
+Configure AKS to automatically upgrade to newer supported AKS versions as they are made available.
+
+## DESCRIPTION
+
+In additional to performing manual upgrades, AKS supports auto-upgrades.
+Auto-upgrades reduces manual intervention required to maintain a AKS cluster.
+
+To configure auto-upgrades select a release channel instead of the default `none`.
+The following release channels are available:
+
+- `none` - Disables auto-upgrades.
+The default setting.
+- `patch` - Automatically upgrade to the latest supported patch version of the current minor version.
+- `stable` - Automatically upgrade to the latest supported patch release of the recommended minor version.
+This is N-1 of the current AKS non-preview minor version.
+- `rapid` - Automatically upgrade to the latest supported patch of the latest support minor version.
+- `node-image` - Automatically upgrade to the latest node image version.
+Normally upgraded weekly.
+
+## RECOMMENDATION
+
+Consider enabling auto-upgrades for AKS clusters by setting an auto-upgrade channel.
+
+### EXAMPLES
+
+### Configure with Azure template
+
+To deploy AKS clusters that pass this rule:
+
+- Set `properties.autoUpgradeProfile.upgradeChannel` to an upgrade channel such as `stable`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular"
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+```bash
+az aks update -n '<name>' -g '<resource_group>' --auto-upgrade-channel 'stable'
+```
+
+## NOTES
+
+This Azure feature is currently in preview.
+To use this feature you must first opt-in by registering the feature on a per-subscription basis.
+
+## LINKS
+
+- [Automation overview](https://docs.microsoft.com/azure/architecture/framework/devops/automation-overview)
+- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
+- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
+- [Set auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#ManagedClusterAutoUpgradeProfile)

--- a/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
+++ b/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
@@ -1,7 +1,7 @@
 ---
 severity: Important
 pillar: Security
-category: General
+category: Optimize
 resource: Azure Kubernetes Service
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.AzurePolicyAddOn.md
 ---
@@ -36,5 +36,6 @@ Azure Policy for AKS Engine and Arc enabled Kubernetes are currently in preview.
 
 ## LINKS
 
+- [Governance, risk, and compliance](https://docs.microsoft.com/azure/architecture/framework/security/governance#audit-and-enforce-policy-compliance)
 - [Understand Azure Policy for Kubernetes clusters](https://docs.microsoft.com/azure/governance/policy/concepts/policy-for-kubernetes)
 - [Overview of securing pods with Azure Policy for AKS](https://docs.microsoft.com/azure/aks/use-pod-security-on-azure-policy)

--- a/docs/rules/en/Azure.AKS.AzureRBAC.md
+++ b/docs/rules/en/Azure.AKS.AzureRBAC.md
@@ -1,0 +1,133 @@
+---
+severity: Important
+pillar: Security
+category: Identity and access management
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.AzureRBAC.md
+---
+
+# Use Azure RBAC for Kubernetes Authorization
+
+## SYNOPSIS
+
+Use Azure RBAC for Kubernetes Authorization with AKS clusters.
+
+## DESCRIPTION
+
+Azure Kubernetes Service (AKS) supports Role-based Access Control (RBAC).
+RBAC is supported using Kubernetes RBAC and optionally Azure RBAC.
+
+- Using Kubernetes RBAC, you can grant users, groups, and service accounts access to cluster resources.
+- Additionally AKS supports granting Azure AD identities access to cluster resources using Azure RBAC.
+
+Using authorization provided by Azure RBAC simplifies and centralizes authorization of Azure AD principals.
+Access to Kubernetes resource can be managed using Azure Resource Manager (ARM).
+
+When Azure RBAC is enabled:
+
+- Azure AD principals will be validated exclusively by Azure RBAC.
+- Kubernetes users and service accounts are exclusively validated by Kubernetes RBAC.
+
+## RECOMMENDATION
+
+Consider using Azure RBAC for Kubernetes Authorization to centralize authorization of Azure AD principals.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy AKS clusters that pass this rule:
+
+- Set `properties.aadProfile.enableAzureRBAC` to `true`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular"
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+```bash
+az aks update -n '<name>' -g '<resource_group>' --enable-azure-rbac
+```
+
+## LINKS
+
+- [Authorization with Azure AD](https://docs.microsoft.com/azure/architecture/framework/security/design-identity-authorization)
+- [Use Azure RBAC for Kubernetes Authorization](https://docs.microsoft.com/azure/aks/manage-azure-rbac)
+- [Access and identity options for Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/concepts-identity#azure-rbac-for-kubernetes-authorization)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/rules/en/Azure.AKS.LocalAccounts.md
+++ b/docs/rules/en/Azure.AKS.LocalAccounts.md
@@ -1,0 +1,136 @@
+---
+severity: Important
+pillar: Security
+category: Identity and access management
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.LocalAccounts.md
+---
+
+# Disable AKS local accounts
+
+## SYNOPSIS
+
+Enforce named user accounts with RBAC assigned permissions.
+
+## DESCRIPTION
+
+AKS clusters support Role-based Access Control (RBAC).
+RBAC allows users, groups, and service accounts to be granted access to resources on an as needed basis.
+Actions performed by each identity can be logged for auditing with Kubernetes audit policies.
+
+Additionally some default cluster local account credentials are enabled by default.
+When enabled, an identity with permissions can perform cluster actions using local account credentials.
+If local account credentials are used, Kubernetes auditing logs the local account instead of named accounts.
+
+In an AKS cluster with local account disabled administrator will be unable to get the clusterAdmin credential.
+For example, using `az aks get-credentials -g '<resource-group>' -n '<cluster-name>' --admin` will fail.
+
+## RECOMMENDATION
+
+Consider enforcing usage of named accounts by disabling local Kubernetes account credentials.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy AKS clusters that pass this rule:
+
+- Set `properties.disableLocalAccounts` to `true`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular"
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+```bash
+az aks update -n '<name>' -g '<resource_group>' --enable-aad --aad-admin-group-object-ids '<aad-group-id>' --disable-local
+```
+
+## NOTES
+
+This Azure feature is currently in preview.
+To use this feature you must first opt-in by registering the feature on a per-subscription basis.
+
+## LINKS
+
+- [Authorization with Azure AD](https://docs.microsoft.com/azure/architecture/framework/security/design-identity-authorization)
+- [Security design principles](https://docs.microsoft.com/azure/architecture/framework/security/security-principles)
+- [Disable local accounts (preview)](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview)
+- [Access and identity options for Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/concepts-identity#azure-ad-integration)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#managedclusterproperties-object)

--- a/docs/rules/en/Azure.AKS.ManagedAAD.md
+++ b/docs/rules/en/Azure.AKS.ManagedAAD.md
@@ -1,0 +1,123 @@
+---
+severity: Important
+pillar: Security
+category: Identity and access management
+resource: Azure Kubernetes Service
+online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.ManagedAAD.md
+---
+
+# Enable AKS-managed Azure AD
+
+## SYNOPSIS
+
+Use AKS-managed Azure AD to simplify authorization and improve security.
+
+## DESCRIPTION
+
+AKS-managed integration provides an easy way to use Azure AD authorization for AKS.
+Previous Azure AD integration with AKS required app registration and management within Azure AD.
+
+## RECOMMENDATION
+
+Consider configuring AKS-managed Azure AD integration for AKS clusters.
+
+## EXAMPLES
+
+### Configure with Azure template
+
+To deploy AKS clusters that pass this rule:
+
+- Set `properties.aadProfile.managed` to `true`.
+
+For example:
+
+```json
+{
+    "comments": "Azure Kubernetes Cluster",
+    "apiVersion": "2020-12-01",
+    "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]"
+    ],
+    "type": "Microsoft.ContainerService/managedClusters",
+    "location": "[parameters('location')]",
+    "name": "[parameters('clusterName')]",
+    "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('identityName'))]": {}
+        }
+    },
+    "properties": {
+        "kubernetesVersion": "[parameters('kubernetesVersion')]",
+        "disableLocalAccounts": true,
+        "enableRBAC": true,
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+            {
+                "name": "system",
+                "osDiskSizeGB": 32,
+                "count": 3,
+                "minCount": 3,
+                "maxCount": 10,
+                "enableAutoScaling": true,
+                "maxPods": 50,
+                "vmSize": "Standard_D2s_v3",
+                "osType": "Linux",
+                "type": "VirtualMachineScaleSets",
+                "vnetSubnetID": "[variables('clusterSubnetId')]",
+                "mode": "System",
+                "osDiskType": "Ephemeral",
+                "scaleSetPriority": "Regular"
+            }
+        ],
+        "aadProfile": {
+            "managed": true,
+            "enableAzureRBAC": true,
+            "adminGroupObjectIDs": "[parameters('clusterAdmins')]",
+            "tenantID": "[subscription().tenantId]"
+        },
+        "networkProfile": {
+            "networkPlugin": "azure",
+            "networkPolicy": "azure",
+            "loadBalancerSku": "Standard",
+            "serviceCidr": "192.168.0.0/16",
+            "dnsServiceIP": "192.168.0.4",
+            "dockerBridgeCidr": "172.17.0.1/16"
+        },
+        "autoUpgradeProfile": {
+            "upgradeChannel": "stable"
+        },
+        "addonProfiles": {
+            "azurepolicy": {
+                "enabled": true,
+                "config": {
+                    "version": "v2"
+                }
+            },
+            "omsagent": {
+                "enabled": true,
+                "config": {
+                    "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
+                }
+            },
+            "kubeDashboard": {
+                "enabled": false
+            }
+        }
+    }
+}
+```
+
+### Configure with Azure CLI
+
+```bash
+az aks update -n '<name>' -g '<resource_group>' --enable-aad --aad-admin-group-object-ids '<group_id>'
+```
+
+## LINKS
+
+- [Authorization with Azure AD](https://docs.microsoft.com/azure/architecture/framework/security/design-identity-authorization)
+- [Security design principles](https://docs.microsoft.com/azure/architecture/framework/security/security-principles)
+- [Access and identity options for Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/concepts-identity#azure-ad-integration)
+- [AKS-managed Azure Active Directory integration](https://docs.microsoft.com/azure/aks/managed-aad)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#ManagedClusterAADProfile)

--- a/docs/rules/en/Azure.AKS.PoolVersion.md
+++ b/docs/rules/en/Azure.AKS.PoolVersion.md
@@ -1,7 +1,7 @@
 ---
 severity: Important
-pillar: Operational Excellence
-category: Deployment
+pillar: Reliability
+category: Design
 resource: Azure Kubernetes Service
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.PoolVersion.md
 ---

--- a/docs/rules/en/Azure.AKS.UseRBAC.md
+++ b/docs/rules/en/Azure.AKS.UseRBAC.md
@@ -27,7 +27,8 @@ Consider redeploying the AKS cluster with RBAC enabled.
 
 ## LINKS
 
-- [Access and identity options for Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/concepts-identity#azure-active-directory-integration)
+- [Access and identity options for Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/concepts-identity#azure-ad-integration)
+- [Authorization with Azure AD](https://docs.microsoft.com/azure/architecture/framework/security/design-identity-authorization)
 - [Best practices for authentication and authorization in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/operator-best-practices-identity#use-azure-active-directory)
 - [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 - [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters#managedclusterproperties-object)

--- a/docs/rules/en/Azure.AKS.Version.md
+++ b/docs/rules/en/Azure.AKS.Version.md
@@ -1,7 +1,7 @@
 ---
 severity: Important
-pillar: Operational Excellence
-category: Deployment
+pillar: Reliability
+category: Design
 resource: Azure Kubernetes Service
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.AKS.Version.md
 ms-content-id: b0bd4e66-af2f-4d0a-82ae-e4738418bb7e
@@ -24,6 +24,20 @@ A list of available Kubernetes versions can be found using the `az aks get-versi
 
 Consider upgrading AKS control plane and nodes pools to the latest stable version of Kubernetes.
 
+## EXAMPLES
+
+### Configure with Azure CLI
+
+```bash
+az aks upgrade -n '<name>' -g '<resource_group>' --kubernetes-version '<version>'
+```
+
+### Configure with Azure PowerShell
+
+```powershell
+Set-AzAksCluster -Name '<name>' -ResourceGroupName '<resource_group>' -KubernetesVersion '<version>'
+```
+
 ## NOTES
 
 To configure this rule:
@@ -32,6 +46,7 @@ To configure this rule:
 
 ## LINKS
 
-- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions)
-- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/support-policies)
-- [Azure template reference](https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters)
+- [Target and non-functional requirements](https://docs.microsoft.com/azure/architecture/framework/resiliency/design-requirements#meet-application-platform-requirements)
+- [Supported Kubernetes versions in Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/supported-kubernetes-versions)
+- [Support policies for Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/support-policies)
+- [Azure template reference](https://docs.microsoft.com/azure/templates/microsoft.containerservice/managedclusters)

--- a/docs/rules/en/Azure.Resource.AllowedRegions.md
+++ b/docs/rules/en/Azure.Resource.AllowedRegions.md
@@ -1,7 +1,7 @@
 ---
 severity: Awareness
 pillar: Security
-category: General
+category: Design
 resource: All resources
 online version: https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/rules/en/Azure.Resource.AllowedRegions.md
 ---

--- a/docs/rules/en/module.md
+++ b/docs/rules/en/module.md
@@ -38,8 +38,6 @@ Name | Synopsis | Severity
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments. | Important
-[Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
-[Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
 [Azure.APIM.CertificateExpiry](Azure.APIM.CertificateExpiry.md) | Renew certificates used for custom domain bindings. | Important
 [Azure.AppConfig.SKU](Azure.AppConfig.SKU.md) | App Configuration should use a minimum size of Standard. | Important
 [Azure.AppGw.MinSku](Azure.AppGw.MinSku.md) | Application Gateway should use a minimum instance size of Medium. | Important
@@ -146,7 +144,7 @@ Name | Synopsis | Severity
 [Azure.AppService.ARRAffinity](Azure.AppService.ARRAffinity.md) | Disable client affinity for stateless services. | Awareness
 [Azure.AppService.HTTP2](Azure.AppService.HTTP2.md) | Use HTTP/2 instead of HTTP/1.x to improve protocol efficiency. | Awareness
 
-### Capacity planning
+### Capacity Planning
 
 Name | Synopsis | Severity
 ---- | -------- | --------
@@ -188,6 +186,14 @@ Name | Synopsis | Severity
 [Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable blob soft delete on Storage Accounts. | Important
 [Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage Accounts not using geo-replicated storage (GRS) may be at risk. | Important
 
+### Design
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
+[Azure.AKS.PoolVersion](Azure.AKS.PoolVersion.md) | AKS node pools should match Kubernetes control plane version. | Important
+[Azure.AKS.Version](Azure.AKS.Version.md) | AKS control plane and nodes pools should use a current stable release. | Important
+
 ### Load balancing and failover
 
 Name | Synopsis | Severity
@@ -219,6 +225,13 @@ Name | Synopsis | Severity
 [Azure.ACR.ImageHealth](Azure.ACR.ImageHealth.md) | Remove container images with known vulnerabilities. | Critical
 [Azure.ACR.Quarantine](Azure.ACR.Quarantine.md) | Enable container image quarantine, scan, and mark images as verified. | Important
 
+### Design
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.Resource.AllowedRegions](Azure.Resource.AllowedRegions.md) | Resources should be deployed to allowed regions. | Awareness
+
 ### Encryption
 
 Name | Synopsis | Severity
@@ -248,18 +261,14 @@ Name | Synopsis | Severity
 [Azure.TrafficManager.Protocol](Azure.TrafficManager.Protocol.md) | Monitor Traffic Manager web-based endpoints with HTTPS. | Important
 [Azure.VM.ADE](Azure.VM.ADE.md) | Use Azure Disk Encryption (ADE). | Important
 
-### General
-
-Name | Synopsis | Severity
----- | -------- | --------
-[Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
-[Azure.Resource.AllowedRegions](Azure.Resource.AllowedRegions.md) | Resources should be deployed to allowed regions. | Awareness
-
 ### Identity and access management
 
 Name | Synopsis | Severity
 ---- | -------- | --------
 [Azure.ACR.AdminUser](Azure.ACR.AdminUser.md) | Use Azure AD identities instead of using the registry admin user. | Critical
+[Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
+[Azure.AKS.LocalAccounts](Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
+[Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | Deploy AKS cluster with role-based access control (RBAC) enabled. | Important
 [Azure.APIM.ManagedIdentity](Azure.APIM.ManagedIdentity.md) | Configure managed identities to access Azure resources. | Important
 [Azure.APIM.ProductApproval](Azure.APIM.ProductApproval.md) | Configure products to require approval. | Important
@@ -308,6 +317,12 @@ Name | Synopsis | Severity
 [Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses. | Important
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Awareness
 [Azure.VNET.UseNSGs](Azure.VNET.UseNSGs.md) | Subnets should have NSGs assigned. | Critical
+
+### Optimize
+
+Name | Synopsis | Severity
+---- | -------- | --------
+[Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
 
 ### Security configuration
 

--- a/docs/rules/en/resource.md
+++ b/docs/rules/en/resource.md
@@ -121,8 +121,13 @@ Name | Synopsis | Severity
 
 Name | Synopsis | Severity
 ---- | -------- | --------
+[Azure.AKS.AuthorizedIPs](Azure.AKS.AuthorizedIPs.md) | Restrict access to API server endpoints to authorized IP addresses. | Important
+[Azure.AKS.AutoUpgrade](Azure.AKS.AutoUpgrade.md) | Configure AKS to automatically upgrade to newer supported AKS versions as they are made available. | Important
 [Azure.AKS.AzurePolicyAddOn](Azure.AKS.AzurePolicyAddOn.md) | Configure Azure Kubernetes Service (AKS) clusters to use Azure Policy Add-on for Kubernetes. | Important
+[Azure.AKS.AzureRBAC](Azure.AKS.AzureRBAC.md) | Use Azure RBAC for Kubernetes Authorization with AKS clusters. | Important
 [Azure.AKS.DNSPrefix](Azure.AKS.DNSPrefix.md) | Azure Kubernetes Service (AKS) cluster DNS prefix should meet naming requirements. | Awareness
+[Azure.AKS.LocalAccounts](Azure.AKS.LocalAccounts.md) | Enforce named user accounts with RBAC assigned permissions. | Important
+[Azure.AKS.ManagedAAD](Azure.AKS.ManagedAAD.md) | Use AKS-managed Azure AD to simplify authorization and improve security. | Important
 [Azure.AKS.ManagedIdentity](Azure.AKS.ManagedIdentity.md) | Configure AKS clusters to use managed identities for managing cluster infrastructure. | Important
 [Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates. | Important
 [Azure.AKS.Name](Azure.AKS.Name.md) | Azure Kubernetes Service (AKS) cluster names should meet naming requirements. | Awareness

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -41,8 +41,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'cluster-B', 'cluster-D', 'cluster-F';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -63,8 +63,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 4;
-            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'system';
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F', 'system';
         }
 
         It 'Azure.AKS.PoolVersion' {
@@ -79,8 +79,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F';
         }
 
         It 'Azure.AKS.UseRBAC' {
@@ -95,8 +95,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C', 'cluster-D', 'cluster-F';
         }
 
         It 'Azure.AKS.NetworkPolicy' {
@@ -111,8 +111,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F';
         }
 
         It 'Azure.AKS.PoolScaleSet' {
@@ -127,8 +127,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'system';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system';
         }
 
         It 'Azure.AKS.NodeMinPods' {
@@ -143,8 +143,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'system';
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-C', 'cluster-D', 'cluster-F', 'system';
         }
 
         It 'Azure.AKS.ManagedIdentity' {
@@ -159,8 +159,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F';
         }
 
         It 'Azure.AKS.StandardLB' {
@@ -175,8 +175,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-D';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'cluster-D', 'cluster-F';
         }
 
         It 'Azure.AKS.AzurePolicyAddOn' {
@@ -191,8 +191,88 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D', 'cluster-F';
+        }
+
+        It 'Azure.AKS.ManagedAAD' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.ManagedAAD' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-C', 'cluster-D';
+            $ruleResult.TargetName | Should -Be 'cluster-D', 'cluster-F';
+        }
+
+        It 'Azure.AKS.AutoUpgrade' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AutoUpgrade' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F';
+        }
+
+        It 'Azure.AKS.AuthorizedIPs' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AuthorizedIPs' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F';
+        }
+
+        It 'Azure.AKS.LocalAccounts' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.LocalAccounts' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F';
+        }
+
+        It 'Azure.AKS.AzureRBAC' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AzureRBAC' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 4;
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-B', 'cluster-C', 'cluster-D';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'cluster-F';
         }
     }
 
@@ -411,6 +491,86 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -BeIn 'clusterA';
+        }
+
+        It 'Azure.AKS.ManagedAAD' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.ManagedAAD' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterB';
+        }
+
+        It 'Azure.AKS.AutoUpgrade' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AutoUpgrade' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterB';
+        }
+
+        It 'Azure.AKS.AuthorizedIPs' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AuthorizedIPs' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterB';
+        }
+
+        It 'Azure.AKS.LocalAccounts' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.LocalAccounts' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterB';
+        }
+
+        It 'Azure.AKS.AzureRBAC' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.AzureRBAC' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterB';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -38,7 +38,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.19.7",
+                "kubernetesVersion": "1.20.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -110,14 +110,14 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2019-10-01",
+            "apiVersion": "2020-12-01",
             "name": "[parameters('clusterName2')]",
             "location": "[parameters('clusterLocation')]",
             "identity": {
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "1.19.7",
+                "kubernetesVersion": "1.20.5",
                 "dnsPrefix": "[concat('dns-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -155,8 +155,45 @@
                         "config": {
                             "logAnalyticsWorkspaceResourceID": "[parameters('workspaceId')]"
                         }
+                    },
+                    "azureKeyvaultSecretsProvider": {
+                        "enabled": true,
+                        "config": {
+                            "enableSecretRotation": "false"
+                        }
+                    },
+                    "openServiceMesh": {
+                        "enabled": true
                     }
                 },
+                "aadProfile": {
+                    "managed": true,
+                    "enableAzureRBAC": true,
+                    "adminGroupObjectIDs": [],
+                    "tenantID": "[subscription().tenantId]"
+                },
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "rapid"
+                },
+                "autoScalerProfile": {
+                    "balance-similar-node-groups": "false",
+                    "expander": "random",
+                    "max-empty-bulk-delete": "10",
+                    "max-graceful-termination-sec": "600",
+                    "max-total-unready-percentage": "45",
+                    "new-pod-scale-up-delay": "0s",
+                    "ok-total-unready-count": "3",
+                    "scale-down-delay-after-add": "10m",
+                    "scale-down-delay-after-delete": "10s",
+                    "scale-down-delay-after-failure": "3m",
+                    "scale-down-unneeded-time": "10m",
+                    "scale-down-unready-time": "20m",
+                    "scale-down-utilization-threshold": "0.5",
+                    "scan-interval": "10s",
+                    "skip-nodes-with-local-storage": "false",
+                    "skip-nodes-with-system-pods": "true"
+                },
+                "disableLocalAccounts": true,
                 "enableRBAC": true,
                 "enablePodSecurityPolicy": false,
                 "networkProfile": {
@@ -166,6 +203,11 @@
                     "serviceCidr": "192.168.0.0/16",
                     "dnsServiceIP": "192.168.0.4",
                     "dockerBridgeCidr": "172.17.0.1/16"
+                },
+                "apiServerAccessProfile": {
+                    "authorizedIpRanges": [
+                        "0.0.0.0/32"
+                    ]
                 }
             }
         },
@@ -183,7 +225,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.19.7",
+                "orchestratorVersion": "1.20.5",
                 "osType": "Linux"
             }
         },

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
         "ResourceName": "cluster-A",
         "Name": "cluster-A",
         "Properties": {
-            "kubernetesVersion": "1.19.7",
+            "kubernetesVersion": "1.20.5",
             "dnsPrefix": "cluster-A",
             "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -18,7 +18,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "AvailabilitySet",
-                    "orchestratorVersion": "1.19.7",
+                    "orchestratorVersion": "1.20.5",
                     "osType": "Linux"
                 }
             ],
@@ -136,7 +136,7 @@
         "ParentResource": null,
         "Properties": {
             "provisioningState": "Succeeded",
-            "kubernetesVersion": "1.19.7",
+            "kubernetesVersion": "1.20.5",
             "dnsPrefix": "cluster-C",
             "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -149,7 +149,7 @@
                     "maxPods": 50,
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
-                    "orchestratorVersion": "1.19.7",
+                    "orchestratorVersion": "1.20.5",
                     "osType": "Linux"
                 }
             ],
@@ -218,7 +218,7 @@
         "Plan": null,
         "Properties": {
             "provisioningState": "Succeeded",
-            "kubernetesVersion": "1.19.7",
+            "kubernetesVersion": "1.20.5",
             "dnsPrefix": "cluster-D",
             "fqdn": "cluster-D-nnnnnnnn.hcp.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -231,7 +231,7 @@
                     "maxPods": 50,
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
-                    "orchestratorVersion": "1.19.7",
+                    "orchestratorVersion": "1.20.5",
                     "nodeLabels": {},
                     "mode": "System",
                     "osType": "Linux",
@@ -371,7 +371,7 @@
             "powerState": {
                 "code": "Running"
             },
-            "orchestratorVersion": "1.19.7",
+            "orchestratorVersion": "1.20.5",
             "nodeLabels": {},
             "mode": "System",
             "osType": "Linux",
@@ -382,5 +382,245 @@
         "ResourceType": "Microsoft.ContainerService/managedClusters/agentPools",
         "Sku": null,
         "Tags": null
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.ContainerService/managedClusters/cluster-F",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-test/providers/Microsoft.ContainerService/managedClusters/cluster-F",
+        "Identity": {
+            "PrincipalId": null,
+            "TenantId": null,
+            "Type": "UserAssigned",
+            "UserAssignedIdentities": null
+        },
+        "Kind": null,
+        "Location": "region",
+        "ManagedBy": null,
+        "ResourceName": "cluster-F",
+        "Name": "cluster-F",
+        "Plan": null,
+        "Properties": {
+            "provisioningState": "Succeeded",
+            "powerState": {
+                "code": "Running"
+            },
+            "kubernetesVersion": "1.20.5",
+            "dnsPrefix": "cluster-F",
+            "fqdn": "cluster-F-00000000.hcp.region.azmk8s.io",
+            "azurePortalFQDN": "cluster-F-00000000.portal.hcp.region.azmk8s.io",
+            "agentPoolProfiles": [
+                {
+                    "name": "system",
+                    "count": 2,
+                    "vmSize": "Standard_D2s_v3",
+                    "osDiskSizeGB": 32,
+                    "osDiskType": "Ephemeral",
+                    "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "maxPods": 50,
+                    "type": "VirtualMachineScaleSets",
+                    "maxCount": 2,
+                    "minCount": 2,
+                    "enableAutoScaling": true,
+                    "provisioningState": "Succeeded",
+                    "powerState": {
+                        "code": "Running"
+                    },
+                    "orchestratorVersion": "1.20.5",
+                    "nodeLabels": {},
+                    "mode": "System",
+                    "osType": "Linux",
+                    "nodeImageVersion": "AKSUbuntu-1804containerd-2021.04.27"
+                }
+            ],
+            "windowsProfile": {
+                "adminUsername": "azureuser",
+                "enableCSIProxy": true
+            },
+            "servicePrincipalProfile": {
+                "clientId": "msi"
+            },
+            "addonProfiles": {
+                "aciConnectorLinux": {
+                    "enabled": true,
+                    "config": {
+                        "SubnetName": "subnet-B"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aciconnectorlinux-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azureKeyvaultSecretsProvider": {
+                    "enabled": true,
+                    "config": {
+                        "enableSecretRotation": "false"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurekeyvaultsecretsprovider-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "azurepolicy": {
+                    "enabled": true,
+                    "config": null,
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/azurepolicy-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "httpApplicationRouting": {
+                    "enabled": true,
+                    "config": {
+                        "HTTPApplicationRoutingZoneName": "0000000000000000000.region.aksapp.io"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/httpapplicationrouting-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "kubeDashboard": {
+                    "enabled": false,
+                    "config": null
+                },
+                "omsagent": {
+                    "enabled": true,
+                    "config": {
+                        "logAnalyticsWorkspaceResourceID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/defaultresourcegroup-eus/providers/microsoft.operationalinsights/workspaces/defaultworkspace-00000000-0000-0000-0000-000000000000-eus"
+                    },
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/omsagent-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                },
+                "openServiceMesh": {
+                    "enabled": true,
+                    "config": {},
+                    "identity": {
+                        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/openservicemesh-cluster-F",
+                        "clientId": "00000000-0000-0000-0000-000000000000",
+                        "objectId": "00000000-0000-0000-0000-000000000000"
+                    }
+                }
+            },
+            "nodeResourceGroup": "MC_rg-test_cluster-F_region",
+            "disableLocalAccounts": true,
+            "enableRBAC": true,
+            "enablePodSecurityPolicy": false,
+            "networkProfile": {
+                "networkPlugin": "azure",
+                "networkPolicy": "azure",
+                "loadBalancerSku": "Standard",
+                "loadBalancerProfile": {
+                    "managedOutboundIPs": {
+                        "count": 1
+                    },
+                    "effectiveOutboundIPs": [
+                        {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MC_rg-test_cluster-F_region/providers/Microsoft.Network/publicIPAddresses/00000000-0000-0000-0000-000000000000"
+                        }
+                    ]
+                },
+                "serviceCidr": "192.168.0.0/16",
+                "dnsServiceIP": "192.168.0.4",
+                "dockerBridgeCidr": "172.17.0.1/16",
+                "outboundType": "loadBalancer"
+            },
+            "aadProfile": {
+                "managed": true,
+                "enableAzureRbac": true,
+                "adminGroupObjectIDs": [],
+                "tenantID": "00000000-0000-0000-0000-000000000000"
+            },
+            "maxAgentPools": 100,
+            "identityProfile": {
+                "kubeletidentity": {
+                    "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/MC_rg-test_cluster-F_region/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-F-agentpool",
+                    "clientId": "00000000-0000-0000-0000-000000000000",
+                    "objectId": "00000000-0000-0000-0000-000000000000"
+                }
+            },
+            "autoScalerProfile": {
+                "balance-similar-node-groups": "false",
+                "expander": "random",
+                "max-empty-bulk-delete": "10",
+                "max-graceful-termination-sec": "600",
+                "max-node-provision-time": "15m",
+                "max-total-unready-percentage": "45",
+                "new-pod-scale-up-delay": "0s",
+                "ok-total-unready-count": "3",
+                "scale-down-delay-after-add": "10m",
+                "scale-down-delay-after-delete": "10s",
+                "scale-down-delay-after-failure": "3m",
+                "scale-down-unneeded-time": "10m",
+                "scale-down-unready-time": "20m",
+                "scale-down-utilization-threshold": "0.5",
+                "scan-interval": "10s",
+                "skip-nodes-with-local-storage": "false",
+                "skip-nodes-with-system-pods": "true"
+            },
+            "autoUpgradeProfile": {
+                "upgradeChannel": "rapid"
+            },
+            "apiServerAccessProfile": {
+                "authorizedIpRanges": [
+                    "0.0.0.0/32"
+                ],
+                "enablePrivateCluster": null,
+                "privateDnsZone": null
+            }
+        },
+        "ResourceGroupName": "rg-test",
+        "Type": "Microsoft.ContainerService/managedClusters",
+        "ResourceType": "Microsoft.ContainerService/managedClusters",
+        "Sku": {
+            "Name": "Basic",
+            "Tier": "Free",
+            "Size": null,
+            "Family": null,
+            "Model": null,
+            "Capacity": null
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": [
+            {
+                "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                "Identity": null,
+                "Kind": null,
+                "Location": null,
+                "ManagedBy": null,
+                "ResourceName": "subnet-A",
+                "Name": "subnet-A",
+                "ExtensionResourceName": null,
+                "ParentResource": "virtualNetworks/vnet-A",
+                "Plan": null,
+                "Properties": {
+                    "provisioningState": "Succeeded",
+                    "addressPrefix": "10.0.0.0/21",
+                    "networkSecurityGroup": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkSecurityGroups/nsg-subnet-A"
+                    },
+                    "routeTable": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/routeTables/route-subnet-A"
+                    },
+                    "ipConfigurations": [],
+                    "serviceEndpoints": [],
+                    "delegations": [],
+                    "privateEndpointNetworkPolicies": "Enabled",
+                    "privateLinkServiceNetworkPolicies": "Enabled"
+                },
+                "ResourceGroupName": "rg-test",
+                "Type": "Microsoft.Network/virtualNetworks/subnets",
+                "ResourceType": "Microsoft.Network/virtualNetworks/subnets",
+                "ExtensionResourceType": null,
+                "Sku": null,
+                "SubscriptionId": null
+            }
+        ]
     }
 ]


### PR DESCRIPTION
## PR Summary

- New rules:
  - Azure Kubernetes Service:
    - Check clusters use AKS-managed Azure AD integration. #436
    - Check clusters have local account disabled (preview). #786
    - Check clusters have an auto-upgrade channel set (preview). #787
    - Check clusters limit access network access to the API server. #788
    - Check clusters used Azure RBAC for Kubernetes authorization. #789)
- Updated rules
  - Azure Kubernetes Service:
    - Updated `Azure.AKS.Version` to 1.20.5. #767

Fixes #436 
Fixes #786 
Fixes #787 
Fixes #788 
Fixes #789 
Fixes #767

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
