### PR TITLE
Fix case and bool parsing issues #793 #794

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -7,6 +7,12 @@ See [troubleshooting guide] for a workaround to this issue.
 
 ## Unreleased
 
+What's changed since v1.4.0:
+
+- Bug fixes:
+  - Fixed boolean string conversion case. [#793](https://github.com/Microsoft/PSRule.Rules.Azure/issues/793)
+  - Fixed case sensitive property matching. [#794](https://github.com/Microsoft/PSRule.Rules.Azure/issues/794)
+
 ## v1.4.0
 
 What's changed since v1.3.2:

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -134,8 +134,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
             if (source is JObject jObject && ExpressionHelpers.TryString(indexResult, out string propertyName))
             {
-                var property = jObject[propertyName];
-                if (property == null)
+                if (!jObject.TryGetValue(propertyName, StringComparison.OrdinalIgnoreCase, out JToken property))
                     throw new ExpressionReferenceException(propertyName, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.PropertyNotFound, propertyName));
 
                 return property;
@@ -160,11 +159,10 @@ namespace PSRule.Rules.Azure.Data.Template
 
             if (result is JObject jObject)
             {
-                var property = jObject.Property(propertyName, StringComparison.OrdinalIgnoreCase);
-                if (property == null)
+                if (!jObject.TryGetValue(propertyName, StringComparison.OrdinalIgnoreCase, out JToken property))
                     throw new ExpressionReferenceException(propertyName, string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.PropertyNotFound, propertyName));
 
-                return property.Value;
+                return property;
             }
 
             if (result is JToken jToken)

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionHelpers.cs
@@ -12,6 +12,9 @@ namespace PSRule.Rules.Azure.Data.Template
 {
     internal static class ExpressionHelpers
     {
+        private const string TRUE = "True";
+        private const string FALSE = "False";
+
         private static readonly CultureInfo AzureCulture = new CultureInfo("en-US");
 
         internal static bool TryString(object o, out string value)
@@ -257,6 +260,27 @@ namespace PSRule.Rules.Azure.Data.Template
                 builder.Append(hash[i].ToString("x2", culture));
             }
             return builder.ToString();
+        }
+
+        internal static bool TryBoolString(object o, out string value)
+        {
+            value = null;
+            if (o is bool bValue)
+            {
+                value = GetBoolString(bValue);
+                return true;
+            }
+            if (o is JValue jValue && jValue.Type == JTokenType.Boolean)
+            {
+                value = GetBoolString(jValue.Value<bool>());
+                return true;
+            }
+            return false;
+        }
+
+        private static string GetBoolString(bool value)
+        {
+            return value ? TRUE : FALSE;
         }
     }
 }

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -1401,6 +1401,9 @@ namespace PSRule.Rules.Azure.Data.Template
             if (args == null || args.Length != 1)
                 throw ArgumentsOutOfRange(nameof(String), args);
 
+            if (ExpressionHelpers.TryBoolString(args[0], out string value))
+                return value;
+
             return JsonConvert.SerializeObject(args[0]);
         }
 

--- a/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
+++ b/tests/PSRule.Rules.Azure.Tests/PSRule.Rules.Azure.Tests.csproj
@@ -73,6 +73,9 @@
     <None Update="Template.Parsing.5.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Template.Parsing.6.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Rules.Azure.Tests/Template.Parsing.6.json
+++ b/tests/PSRule.Rules.Azure.Tests/Template.Parsing.6.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "variables": {
+        "lookup": {
+            "True": {
+                "value": "True"
+            },
+            "true": {
+                "value": "true"
+            },
+            "false": {
+                "value": "false"
+            },
+            "other": {
+                "value": "other"
+            },
+            "Other": {
+                "value": "Other"
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Namespace/resourceType",
+            "apiVersion": "2020-05-01",
+            "name": "resource",
+            "location": "region",
+            "properties": {
+                "value1": "[variables('lookup')[string(empty(''))].value]",
+                "value2": "[variables('lookup')[tolower(string(empty('')))].value]",
+                "value3": "[variables('lookup')[string(not(empty('')))].value]",
+                "value4": "[variables('lookup')['Other'].value]"
+            }
+        }
+    ]
+}

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -168,6 +168,20 @@ namespace PSRule.Rules.Azure
             Assert.EndsWith("Resources.Template.json", actual1["_PSRule"]["source"][0]["file"].Value<string>());
         }
 
+        [Fact]
+        public void BooleanStringProperty()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Template.Parsing.6.json"), null);
+            Assert.NotNull(resources);
+            Assert.Single(resources);
+
+            var actual1 = resources[0];
+            Assert.Equal("True", actual1["properties"]["value1"].Value<string>());
+            Assert.Equal("true", actual1["properties"]["value2"].Value<string>());
+            Assert.Equal("false", actual1["properties"]["value3"].Value<string>());
+            Assert.Equal("Other", actual1["properties"]["value4"].Value<string>());
+        }
+
         #region Helper methods
 
         private static string GetSourcePath(string fileName)


### PR DESCRIPTION
## PR Summary

- Fixed boolean string conversion case. #793
- Fixed case sensitive property matching. #794

Fixes #793 
Fixes #794 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
