### PR TITLE
Fixed automatic expansion of parameter files #796

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ The following conceptual topics exist in the `PSRule.Rules.Azure` module:
   - [Azure_AKSNodeMinimumMaxPods](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_aksnodeminimummaxpods)
   - [Azure_AllowedRegions](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_allowedregions)
   - [Azure_MinimumCertificateLifetime](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_minimumcertificatelifetime)
+  - [AZURE_PARAMETER_FILE_EXPANSION](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_parameter_file_expansion)
   - [AZURE_POLICY_WAIVER_MAX_EXPIRY](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_policy_waiver_max_expiry)
   - [AZURE_RESOURCE_GROUP](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_resource_group)
   - [AZURE_SUBSCRIPTION](docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md#azure_subscription)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -12,6 +12,9 @@ What's changed since v1.4.0:
 - Bug fixes:
   - Fixed boolean string conversion case. [#793](https://github.com/Microsoft/PSRule.Rules.Azure/issues/793)
   - Fixed case sensitive property matching. [#794](https://github.com/Microsoft/PSRule.Rules.Azure/issues/794)
+  - Fixed automatic expansion of template parameter files. [#796](https://github.com/Microsoft/PSRule.Rules.Azure/issues/796)
+    - Template parameter files are not automatically expanded by default.
+    - To enable this, set the `AZURE_PARAMETER_FILE_EXPANSION` configuration option.
 
 ## v1.4.0
 

--- a/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
+++ b/docs/concepts/PSRule.Rules.Azure/en-US/about_PSRule_Azure_Configuration.md
@@ -21,6 +21,7 @@ The following configurations options are available for use:
 - [Azure_AKSNodeMinimumMaxPods](#azure_aksnodeminimummaxpods)
 - [Azure_AllowedRegions](#azure_allowedregions)
 - [Azure_MinimumCertificateLifetime](#azure_minimumcertificatelifetime)
+- [AZURE_PARAMETER_FILE_EXPANSION](#azure_parameter_file_expansion)
 - [AZURE_POLICY_WAIVER_MAX_EXPIRY](#azure_policy_waiver_max_expiry)
 - [AZURE_RESOURCE_GROUP](#azure_resource_group)
 - [AZURE_SUBSCRIPTION](#azure_subscription)
@@ -140,6 +141,36 @@ Example:
 # YAML: Set the Azure_MinimumCertificateLifetime configuration option to 90
 configuration:
   Azure_MinimumCertificateLifetime: 90
+```
+
+### AZURE_PARAMETER_FILE_EXPANSION
+
+This configuration option determines if Azure template parameter files will automatically be expanded.
+By default, parameter files will not be automatically expanded.
+
+Parameter files are expanded when PSRule cmdlets with the `-Format File` parameter are used.
+
+Syntax:
+
+```yaml
+configuration:
+  AZURE_PARAMETER_FILE_EXPANSION: bool
+```
+
+Default:
+
+```yaml
+# YAML: The default AZURE_PARAMETER_FILE_EXPANSION configuration option
+configuration:
+  AZURE_PARAMETER_FILE_EXPANSION: false
+```
+
+Example:
+
+```yaml
+# YAML: Set the AZURE_PARAMETER_FILE_EXPANSION configuration option to enable expansion
+configuration:
+  AZURE_PARAMETER_FILE_EXPANSION: true
 ```
 
 ### AZURE_POLICY_WAIVER_MAX_EXPIRY

--- a/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
+++ b/src/PSRule.Rules.Azure/rules/Config.Rule.yaml
@@ -24,6 +24,8 @@ spec:
       resourceId: [ 'ResourceId' ]
       subscriptionId: [ 'SubscriptionId' ]
       resourceGroupName: [ 'ResourceGroupName' ]
+  configuration:
+    AZURE_PARAMETER_FILE_EXPANSION: false
   convention:
     include:
     - 'Azure.ExpandTemplate'

--- a/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Conventions.Rule.ps1
@@ -6,7 +6,7 @@
 #
 
 # Synopsis: Expand Azure resources from parameter files.
-Export-PSRuleConvention 'Azure.ExpandTemplate' -If { $TargetObject.Extension -eq '.json' -and $Assert.HasJsonSchema($PSRule.GetContentFirstOrDefault($TargetObject), @(
+Export-PSRuleConvention 'Azure.ExpandTemplate' -If { $Configuration.AZURE_PARAMETER_FILE_EXPANSION -eq $True -and $TargetObject.Extension -eq '.json' -and $Assert.HasJsonSchema($PSRule.GetContentFirstOrDefault($TargetObject), @(
     "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json`#"
     "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json`#"
 ), $True) } -Begin {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Convention.Tests.ps1
@@ -31,10 +31,19 @@ Describe 'Azure.ExpandTemplate' -Tag 'Convention' {
                 ErrorAction = 'Stop'
             }
 
+            # Default
             $parameterFile = Join-Path -Path $here -ChildPath 'Resources.Storage.Parameters.json';
             $result = @(Invoke-PSRule @invokeParams -InputPath $parameterFile -Format File);
-            $result.Length | Should -BeGreaterThan 1;
+            $result.Length | Should -Be 1;
+            $resource = $result | Where-Object { $_.TargetType -eq 'Microsoft.Storage/storageAccounts' };
+            $resource | Should -BeNullOrEmpty;
 
+            # Expand templates
+            $option = @{
+                'Configuration.AZURE_PARAMETER_FILE_EXPANSION' = $True
+            }
+            $result = @(Invoke-PSRule @invokeParams -InputPath $parameterFile -Format File -Option $option);
+            $result.Length | Should -BeGreaterThan 1;
             $resource = $result | Where-Object { $_.TargetType -eq 'Microsoft.Storage/storageAccounts' };
             $resource | Should -Not -BeNullOrEmpty;
             $resource.TargetName | Should -BeIn 'storage1'


### PR DESCRIPTION
## PR Summary

- Fixed automatic expansion of template parameter files. #796
  - Template parameter files are not automatically expanded by default.
  - To enable this, set the `AZURE_PARAMETER_FILE_EXPANSION` configuration option.

Fixes #796 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Other code changes**
  - [x] Unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.Azure/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
